### PR TITLE
Updates FAISS op to copy nearest neighbor search index into export path

### DIFF
--- a/merlin/systems/dag/ops/faiss.py
+++ b/merlin/systems/dag/ops/faiss.py
@@ -22,7 +22,6 @@ import faiss
 import numpy as np
 from merlin.dag import ColumnSelector
 from merlin.schema import ColumnSchema, Schema
-
 from merlin.systems.dag.ops.operator import InferenceDataFrame, PipelineableInferenceOperator
 
 


### PR DESCRIPTION
This PR fixes #14
The Faiss Operator now supports migrating the leveraged index into the triton models directory. This puts all artifacts in the triton model directory.