### PR TITLE
Automate pushing package to pypi

### DIFF
--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -1,8 +1,11 @@
 name: CPU CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
+    tags:
+      - v*
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened, closed]
@@ -51,6 +54,14 @@ jobs:
     - name: Run unittests
       run: |
         python -m pytest -rxs tests/unit/
+    - name: Generate package for pypi
+      run: |
+        python setup.py sdist
+    - name: Upload artifacts to github
+      uses: actions/upload-artifact@v2
+      with:
+        name: dist
+        path: dist
 
     # Build docs, treat warnings as errors
     - name: Building docs
@@ -74,3 +85,28 @@ jobs:
       with:
         name: pr
         path: pr/
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [build]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist
+      - name: Create GitHub Release
+        uses: fnkr/github-action-ghr@v1.3
+        env:
+          GHR_PATH: .
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Push to PyPi
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          pip install --upgrade wheel pip setuptools twine
+          twine upload *


### PR DESCRIPTION
After tagging a release, this will automatically push the package the pypi as well as create the github release attaching the same sdist package to the release attachments.

Based on NVIDIA-Merlin/core#30 by @benfred