### PR TITLE
Fixes notebook bug bash edition

### DIFF
--- a/examples/Getting_Started/Getting-started-with-Merlin-Systems.ipynb
+++ b/examples/Getting_Started/Getting-started-with-Merlin-Systems.ipynb
@@ -84,24 +84,25 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/raid/workshared/nvtabular/nvtabular/graph.py:23: FutureWarning: The `nvtabular.graph` module has moved to `merlin.dag`. Support for importing from `nvtabular.graph` is deprecated, and will be removed in a future version. Please update your imports to import from `merlin.dag`.\n",
+      "/nvtabular/nvtabular/graph.py:23: FutureWarning: The `nvtabular.graph` module has moved to `merlin.dag`. Support for importing from `nvtabular.graph` is deprecated, and will be removed in a future version. Please update your imports to import from `merlin.dag`.\n",
       "  warnings.warn(\n",
-      "/raid/workshared/nvtabular/nvtabular/io.py:23: FutureWarning: The `nvtabular.io` module has moved to `merlin.io`. Support for importing from `nvtabular.io` is deprecated, and will be removed in a future version. Please update your imports to import from `merlin.io`.\n",
+      "/nvtabular/nvtabular/io.py:23: FutureWarning: The `nvtabular.io` module has moved to `merlin.io`. Support for importing from `nvtabular.io` is deprecated, and will be removed in a future version. Please update your imports to import from `merlin.io`.\n",
       "  warnings.warn(\n",
-      "/raid/workshared/nvtabular/nvtabular/utils.py:23: FutureWarning: The `nvtabular.utils` module has moved to `merlin.core.utils`. Support for importing from `nvtabular.utils` is deprecated, and will be removed in a future version. Please update your imports to import from `merlin.core.utils`.\n",
+      "/nvtabular/nvtabular/utils.py:23: FutureWarning: The `nvtabular.utils` module has moved to `merlin.core.utils`. Support for importing from `nvtabular.utils` is deprecated, and will be removed in a future version. Please update your imports to import from `merlin.core.utils`.\n",
       "  warnings.warn(\n",
-      "/raid/workshared/nvtabular/nvtabular/dispatch.py:23: FutureWarning: The `nvtabular.dispatch` module has moved to `merlin.core.dispatch`. Support for importing from `nvtabular.dispatch` is deprecated, and will be removed in a future version. Please update your imports to import from `merlin.core.dispatch`.\n",
+      "/nvtabular/nvtabular/dispatch.py:23: FutureWarning: The `nvtabular.dispatch` module has moved to `merlin.core.dispatch`. Support for importing from `nvtabular.dispatch` is deprecated, and will be removed in a future version. Please update your imports to import from `merlin.core.dispatch`.\n",
       "  warnings.warn(\n"
      ]
     }
    ],
    "source": [
     "import os\n",
+    "os.environ['INPUT_FOLDER'] = '/models/examples/processed'\n",
+    "os.environ['DATA_FOLDER'] = '/raid/data/ali'\n",
     "os.environ[\"TF_GPU_ALLOCATOR\"]=\"cuda_malloc_async\"\n",
     "from nvtabular.workflow import Workflow\n",
     "\n",
-    "origin_path =  '/workspace/data/'\n",
-    "input_path = os.path.join(origin_path,'processed')\n",
+    "input_path = os.environ.get(\"INPUT_FOLDER\", \"/workspace/data/\")\n",
     "\n",
     "workflow_stored_path = os.path.join(input_path, \"workflow\")\n",
     "\n",
@@ -125,7 +126,7 @@
     {
      "data": {
       "text/plain": [
-       "<nvtabular.workflow.workflow.Workflow at 0x7fc3dc4d3fa0>"
+       "<nvtabular.workflow.workflow.Workflow at 0x7f442c402550>"
       ]
      },
      "execution_count": 3,
@@ -160,14 +161,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/lib/python3/dist-packages/requests/__init__.py:89: RequestsDependencyWarning: urllib3 (1.26.8) or chardet (3.0.4) doesn't match a supported version!\n",
-      "  warnings.warn(\"urllib3 ({}) or chardet ({}) doesn't match a supported \"\n",
-      "2022-03-29 20:12:54.602705: I tensorflow/core/platform/cpu_feature_guard.cc:151] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F FMA\n",
+      "2022-03-30 19:38:59.531435: I tensorflow/core/platform/cpu_feature_guard.cc:151] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F FMA\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2022-03-29 20:12:57.365824: I tensorflow/core/common_runtime/gpu/gpu_process_state.cc:214] Using CUDA malloc Async allocator for GPU: 0\n",
-      "2022-03-29 20:12:57.366022: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 43909 MB memory:  -> device: 0, name: Quadro RTX 8000, pci bus id: 0000:15:00.0, compute capability: 7.5\n",
-      "2022-03-29 20:12:57.366597: I tensorflow/core/common_runtime/gpu/gpu_process_state.cc:214] Using CUDA malloc Async allocator for GPU: 1\n",
-      "2022-03-29 20:12:57.366655: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:1 with 43905 MB memory:  -> device: 1, name: Quadro RTX 8000, pci bus id: 0000:2d:00.0, compute capability: 7.5\n"
+      "2022-03-30 19:39:01.547568: I tensorflow/core/common_runtime/gpu/gpu_process_state.cc:214] Using CUDA malloc Async allocator for GPU: 0\n",
+      "2022-03-30 19:39:01.547720: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 35814 MB memory:  -> device: 0, name: Quadro RTX 8000, pci bus id: 0000:15:00.0, compute capability: 7.5\n",
+      "2022-03-30 19:39:01.548314: I tensorflow/core/common_runtime/gpu/gpu_process_state.cc:214] Using CUDA malloc Async allocator for GPU: 1\n",
+      "2022-03-30 19:39:01.548374: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:1 with 43332 MB memory:  -> device: 1, name: Quadro RTX 8000, pci bus id: 0000:2d:00.0, compute capability: 7.5\n",
+      "2022-03-30 19:39:04.003205: W tensorflow/core/framework/cpu_allocator_impl.cc:82] Allocation of 788046592 exceeds 10% of free system memory.\n",
+      "2022-03-30 19:39:04.003322: W tensorflow/core/framework/cpu_allocator_impl.cc:82] Allocation of 788046592 exceeds 10% of free system memory.\n",
+      "2022-03-30 19:39:04.057883: W tensorflow/core/framework/cpu_allocator_impl.cc:82] Allocation of 788046592 exceeds 10% of free system memory.\n"
      ]
     }
    ],
@@ -258,28 +260,28 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-03-29 20:13:02.972577: W tensorflow/python/util/util.cc:368] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n",
-      "WARNING:absl:Found untraced functions such as restored_function_body, restored_function_body, restored_function_body, restored_function_body, click/binary_classification_task/output_layer_layer_call_fn while saving (showing 5 of 48). These functions will not be directly callable after loading.\n"
+      "2022-03-30 19:39:05.797447: W tensorflow/python/util/util.cc:368] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n",
+      "WARNING:absl:Found untraced functions such as restored_function_body, restored_function_body, restored_function_body, restored_function_body, click/binary_classification_task/output_layer_layer_call_fn while saving (showing 5 of 48). These functions will not be directly callable after loading.\n",
+      "2022-03-30 19:39:07.239921: W tensorflow/core/framework/cpu_allocator_impl.cc:82] Allocation of 788046592 exceeds 10% of free system memory.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:tensorflow:Assets written to: /workspace/data/processed/ensemble/1_predicttensorflow/1/model.savedmodel/assets\n"
+      "INFO:tensorflow:Assets written to: /models/examples/processed/ensemble/1_predicttensorflow/1/model.savedmodel/assets\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:tensorflow:Assets written to: /workspace/data/processed/ensemble/1_predicttensorflow/1/model.savedmodel/assets\n"
+      "INFO:tensorflow:Assets written to: /models/examples/processed/ensemble/1_predicttensorflow/1/model.savedmodel/assets\n"
      ]
     }
    ],
    "source": [
     "from merlin.systems.dag.ensemble import Ensemble\n",
-    "from merlin.schema import Schema, ColumnSchema\n",
     "import numpy as np\n",
     "\n",
     "\n",
@@ -326,7 +328,7 @@
     "\n",
     "After we export the ensemble, we are ready to start the Triton Inference Server. First ensure it is installed in your environment otherwise find more install information here[link to triton build and install documentation]. Once installation is verified, you can start triton server by using the following command:\n",
     "\n",
-    "`tritonserver --model-repository=/ensemble_export_path/`\n",
+    "`tritonserver --model-repository=/ensemble_export_path/ --backend-config=tensorflow,version=2`\n",
     "\n",
     "For the `--model-repository` argument, specify the same value as the `export_path` that you specified previously in the `ensemble.export` method."
    ]
@@ -567,15 +569,14 @@
     }
    ],
    "source": [
-    "import tritonclient.grpc as grpcclient\n",
-    "from merlin.systems.triton import convert_df_to_triton_input\n",
     "from merlin.core.dispatch import get_lib\n",
     "\n",
     "df_lib = get_lib()\n",
+    "original_data_path = os.environ.get(\"DATA_FOLDER\", \"/workspace/data/\")\n",
     "\n",
     "# read in data for request\n",
     "batch = df_lib.read_parquet(\n",
-    "    os.path.join(origin_path,\"test\", \"*.parquet\"), num_rows=3, columns=workflow.input_schema.column_names\n",
+    "    os.path.join(original_data_path,\"test\", \"test_0.parquet\"), num_rows=3, columns=workflow.input_schema.column_names\n",
     ")\n",
     "batch"
    ]
@@ -595,6 +596,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from merlin.systems.triton import convert_df_to_triton_input\n",
+    "import tritonclient.grpc as grpcclient\n",
     "# create inputs and outputs\n",
     "\n",
     "inputs = convert_df_to_triton_input(workflow.input_schema.column_names, batch, grpcclient.InferInput)\n",
@@ -644,9 +647,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "output_1 [[0.04504055]\n",
-      " [0.04869035]\n",
-      " [0.00892087]] (3, 1)\n"
+      "output_1 [[0.05209467]\n",
+      " [0.05619942]\n",
+      " [0.01078821]] (3, 1)\n"
      ]
     }
    ],
@@ -655,6 +658,14 @@
     "for col in ensemble.graph.output_schema.column_names:\n",
     "    print(col, response.as_numpy(col), response.as_numpy(col).shape)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e355213d-e452-4d43-8bba-d36b7f5694bb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/Getting_Started/Getting-started-with-Merlin-Systems.ipynb
+++ b/examples/Getting_Started/Getting-started-with-Merlin-Systems.ipynb
@@ -97,8 +97,6 @@
    ],
    "source": [
     "import os\n",
-    "os.environ['INPUT_FOLDER'] = '/models/examples/processed'\n",
-    "os.environ['DATA_FOLDER'] = '/raid/data/ali'\n",
     "os.environ[\"TF_GPU_ALLOCATOR\"]=\"cuda_malloc_async\"\n",
     "from nvtabular.workflow import Workflow\n",
     "\n",


### PR DESCRIPTION
To make the notebook more user-friendly and robust we have added more detail around the tritonserver command to make explicit the loading of version 2 of tensorflow backend (used to work by default). And we also introduced two separate variables as load directories for the workflow model created models example that runs before this notebook and the original dataset before workflow is applied. 