### PR TITLE
fix links in nb

### DIFF
--- a/examples/Getting_Started/Getting-started-with-Merlin-Systems.ipynb
+++ b/examples/Getting_Started/Getting-started-with-Merlin-Systems.ipynb
@@ -34,7 +34,7 @@
     "\n",
     "## Overview\n",
     "\n",
-    "NVIDIA Merlin is an open source framework that accelerates and scales end-to-end recommender system pipelines on GPU. The Merlin framework is broken up into several sub components, these include: merlin-core, merlin-models, NVTabular and merlin-systems. Merlin Systems will be the focus of this example.\n",
+    "NVIDIA Merlin is an open source framework that accelerates and scales end-to-end recommender system pipelines on GPU. The Merlin framework is broken up into several sub components, these include: Merlin-Core, Merlin-Models, NVTabular and Merlin-Systems. Merlin Systems will be the focus of this example.\n",
     "\n",
     "The purpose of the Merlin Systems library is to make it easy for Merlin users to quickly deploy their recommender systems from development to triton. We extended the same user-friendly API users are accustomed to in NVTabular and leveraged it to accommodate deploying your recommender system components to triton. \n",
     "\n",

--- a/examples/Getting_Started/Getting-started-with-Merlin-Systems.ipynb
+++ b/examples/Getting_Started/Getting-started-with-Merlin-Systems.ipynb
@@ -71,7 +71,7 @@
    "source": [
     "## Load an NVTabular Workflow\n",
     "\n",
-    "First, we load the `nvtabular.Workflow` that we created in with this [example](https://github.com/NVIDIA-Merlin/models/blob/main/examples/04-Retrieval-Model.ipynb). "
+    "First, we load the `nvtabular.Workflow` that we created in with this [example](https://github.com/NVIDIA-Merlin/models/blob/main/examples/04-Exporting-ranking-models.ipynb). "
    ]
   },
   {
@@ -146,7 +146,7 @@
    "source": [
     "## Load a Tensorflow Model\n",
     "\n",
-    "After loading the workflow, we load the model. This model was trained with the output of the workflow from this [example](https://github.com/NVIDIA-Merlin/models/blob/main/examples/04-Retrieval-Model.ipynb)."
+    "After loading the workflow, we load the model. This model was trained with the output of the workflow from this [example](https://github.com/NVIDIA-Merlin/models/blob/main/examples/04-Exporting-ranking-models.ipynb)."
    ]
   },
   {

--- a/examples/Getting_Started/Getting-started-with-Merlin-Systems.ipynb
+++ b/examples/Getting_Started/Getting-started-with-Merlin-Systems.ipynb
@@ -34,7 +34,7 @@
     "\n",
     "## Overview\n",
     "\n",
-    "NVIDIA Merlin is an open source framework that accelerates and scales end-to-end recommender system pipelines on GPU. The Merlin framework is broken up into several sub components, these include: Merlin-Core, Merlin-Models, NVTabular and Merlin-Systems. Merlin Systems will be the focus of this example.\n",
+    "NVIDIA Merlin is an open source framework that accelerates and scales end-to-end recommender system pipelines. The Merlin framework is broken up into several sub components, these include: Merlin-Core, Merlin-Models, NVTabular and Merlin-Systems. Merlin Systems will be the focus of this example.\n",
     "\n",
     "The purpose of the Merlin Systems library is to make it easy for Merlin users to quickly deploy their recommender systems from development to triton. We extended the same user-friendly API users are accustomed to in NVTabular and leveraged it to accommodate deploying your recommender system components to triton. \n",
     "\n",


### PR DESCRIPTION
this fixes the dead links to the previous notebook in this example set in both nvtabular and models sections. Also fixes the capitalization of the merlin libraries in intro of nb.