### PR TITLE
chore: Specify new directory for reused workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,10 +10,10 @@ on:
     # Only following types are handled by the action, but one can default to all as well
     types: [opened, reopened, synchronize]
   # pull_request_target event is required for autolabeler to support PRs from forks
-  pull_request_target:
-    types: [opened, reopened, synchronize]
+  # pull_request_target:
+  #  types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 jobs:
   update_release_draft:
-    uses: nvidia-merlin/.github/workflows/release-drafter-common.yaml@main
+    uses: nvidia-merlin/.github/.github/workflows/release-drafter-common.yaml@main


### PR DESCRIPTION
GitHub insists that reusable workflows must be
in a `.github/workflows` directory.  My nitpickiness
causes me to assert some eyestrain at
`.github/.github./...` but that's how it's done.