### PR TITLE
Update setup.py to only publish the merlin namespace

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@
 import os
 import sys
 
-from setuptools import find_namespace_packages, find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 try:
     import versioneer
@@ -40,7 +40,7 @@ install_reqs = parse_requirements("./requirements.txt")
 setup(
     name="merlin-systems",
     version=versioneer.get_version(),
-    packages=find_packages() + find_namespace_packages(),
+    packages=find_namespace_packages(include=["merlin*"]),
     url="https://github.com/NVIDIA-Merlin/systems",
     author="NVIDIA Corporation",
     license="Apache 2.0",


### PR DESCRIPTION
The configuration of setup.py currently builds the tests along with the code. This change restricts published packages to the merlin namespace only.

## Implementation Details

- Add include to restrict build files in `find_namespace_packages` to restrict to the `merlin` namespace. And avoid publishing docs and tests folders.
- Removing `find_packages` - this doesn't find anything because we're using a namespace layout without an `__init__.py` file.

[Reference: setuptools docs -Finding namespace packages](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#finding-namespace-packages)

![image](https://user-images.githubusercontent.com/1216955/171032670-c5bfb2bc-cfb2-4fc0-a1c7-f31c64315117.png)

## Files in build

### Before

```
build
`-- lib
    |-- docs
    |   `-- source
    |       `-- conf.py
    |-- merlin
    |   `-- systems
    |       |-- __init__.py
    |       |-- _version.py
    |       |-- dag
    |       |   |-- __init__.py
    |       |   |-- ensemble.py
    |       |   |-- node.py
    |       |   |-- op_runner.py
    |       |   `-- ops
    |       |       |-- __init__.py
    |       |       |-- faiss.py
    |       |       |-- feast.py
    |       |       |-- operator.py
    |       |       |-- session_filter.py
    |       |       |-- softmax_sampling.py
    |       |       |-- tensorflow.py
    |       |       |-- unroll_features.py
    |       |       `-- workflow.py
    |       |-- triton
    |       |   |-- __init__.py
    |       |   |-- conversions.py
    |       |   |-- export.py
    |       |   |-- oprunner_model.py
    |       |   |-- utils.py
    |       |   `-- workflow_model.py
    |       `-- workflow
    |           |-- __init__.py
    |           |-- base.py
    |           |-- hugectr.py
    |           |-- pytorch.py
    |           `-- tensorflow.py
    `-- tests
        |-- __init__.py
        |-- conftest.py
        `-- unit
            |-- __init__.py
            |-- systems
            |   |-- __init__.py
            |   |-- test_ensemble.py
            |   |-- test_ensemble_ops.py
            |   |-- test_export.py
            |   |-- test_graph.py
            |   |-- test_inference_ops.py
            |   |-- test_op_runner.py
            |   |-- test_tensorflow_inf_op.py
            |   `-- utils
            |       |-- __init__.py
            |       |-- ops.py
            |       |-- tf.py
            |       |-- torch.py
            |       `-- triton.py
            `-- test_version.py
```

### After

```
build/
`-- lib
    `-- merlin
        `-- systems
            |-- __init__.py
            |-- _version.py
            |-- dag
            |   |-- __init__.py
            |   |-- ensemble.py
            |   |-- node.py
            |   |-- op_runner.py
            |   `-- ops
            |       |-- __init__.py
            |       |-- faiss.py
            |       |-- feast.py
            |       |-- operator.py
            |       |-- session_filter.py
            |       |-- softmax_sampling.py
            |       |-- tensorflow.py
            |       |-- unroll_features.py
            |       `-- workflow.py
            |-- triton
            |   |-- __init__.py
            |   |-- conversions.py
            |   |-- export.py
            |   |-- oprunner_model.py
            |   |-- utils.py
            |   `-- workflow_model.py
            `-- workflow
                |-- __init__.py
                |-- base.py
                |-- hugectr.py
                |-- pytorch.py
                `-- tensorflow.py
```