### PR TITLE
Fix broken PoC notebook due mismatching output names between config file and saved ranking model

### DIFF
--- a/merlin/systems/dag/ops/tensorflow.py
+++ b/merlin/systems/dag/ops/tensorflow.py
@@ -79,7 +79,7 @@ class PredictTensorflow(InferenceOperator):
         outputs = list(default_signature.structured_outputs.values())
 
         input_col_names = [col.name.split("/")[0] for col in inputs]
-        output_col_names = [col.name.split("/")[0] for col in outputs]
+        output_col_names = [col.name for col in outputs]
 
         self.input_schema = Schema()
         for col, input_col in zip(input_col_names, inputs):
@@ -173,7 +173,7 @@ class PredictTensorflow(InferenceOperator):
             # this assumes the list columns are 1D tensors both for cats and conts
             config.output.append(
                 model_config.ModelOutput(
-                    name=col.name.split("/")[0],
+                    name=col.name,
                     data_type=_convert_dtype(col.dtype),
                     dims=[-1, col.shape[1]],
                 )


### PR DESCRIPTION
Currently,  [02-Deploying-multi-stage-RecSys-with-Merlin-Systems.ipynb](https://github.com/NVIDIA-Merlin/Merlin/blob/main/examples/Building-and-deploying-multi-stage-RecSys/02-Deploying-multi-stage-RecSys-with-Merlin-Systems.ipynb) nb is broken, due to ranking model output name mismatch between the config files, and saved model.

we get the following errors:

`ValueError: Missing columns ['output_1'] found in operatorSubsetColumns during compute_input_schema.`

This can be fixed by setting the proper output name `click/click/binary_classification_task` in  the following lines:

```
ordering = combined_features["item_id"] >> SoftmaxSampling(
    relevance_col=ranking["click"], topk=top_k, temperature=20.0
)
```

However, this is not enough. Triton also complains about output names, therefoer cannot load `5_predicttensorflow` model.

This PR proposes a solution to that issue.