### PR TITLE
Add Forest Inference Operator 

### DIFF
--- a/merlin/systems/dag/ops/compat.py
+++ b/merlin/systems/dag/ops/compat.py
@@ -31,3 +31,7 @@ try:
     import cuml.ensemble as cuml_ensemble
 except ImportError:
     cuml_ensemble = None
+try:
+    import triton_python_backend_utils as pb_utils
+except ImportError:
+    pb_utils = None

--- a/merlin/systems/dag/ops/fil.py
+++ b/merlin/systems/dag/ops/fil.py
@@ -1,3 +1,18 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 import json
 import pathlib
 import pickle

--- a/merlin/systems/dag/ops/fil.py
+++ b/merlin/systems/dag/ops/fil.py
@@ -121,7 +121,15 @@ class FIL(InferenceOperator):
         """Returns output schema for FIL op"""
         return Schema([ColumnSchema("output__0", dtype=np.float32)])
 
-    def export(self, path, input_schema, output_schema, node_id=None, version=1):
+    def export(
+        self,
+        path,
+        input_schema,
+        output_schema,
+        params: dict = None,
+        node_id=None,
+        version=1,
+    ):
         """Export the model to the supplied path. Returns the config"""
         node_name = f"{node_id}_{self.export_name}" if node_id is not None else self.export_name
         node_export_path = pathlib.Path(path) / node_name

--- a/merlin/systems/dag/ops/fil.py
+++ b/merlin/systems/dag/ops/fil.py
@@ -139,7 +139,7 @@ class Forest(PipelineableInferenceOperator):
         )
         inference_response = inference_request.exec()
         output0 = pb_utils.get_output_tensor_by_name(inference_response, "output__0")
-        return InferenceDataFrame({"output__0": output0.as_numpy()})
+        return InferenceDataFrame({"output__0": output0})
 
 
 class FIL(InferenceOperator):

--- a/merlin/systems/dag/ops/fil.py
+++ b/merlin/systems/dag/ops/fil.py
@@ -24,21 +24,26 @@ from google.protobuf import text_format  # noqa
 
 from merlin.dag import ColumnSelector  # noqa
 from merlin.schema import ColumnSchema, Schema  # noqa
-from merlin.systems.dag.ops.compat import cuml_ensemble, lightgbm, sklearn_ensemble, xgboost
+from merlin.systems.dag.ops.compat import (
+    cuml_ensemble,
+    lightgbm,
+    pb_utils,
+    sklearn_ensemble,
+    xgboost,
+)
 from merlin.systems.dag.ops.operator import (
     InferenceDataFrame,
     InferenceOperator,
     PipelineableInferenceOperator,
 )
 
-try:
-    import triton_python_backend_utils as pb_utils
-except ImportError:
-    pb_utils = None
 
+class PredictForest(PipelineableInferenceOperator):
+    """Operator for running inference on Forest models.
 
-class Forest(PipelineableInferenceOperator):
-    """Operator for running Forest models.
+    This works for gradient-boosted decision trees (GBDTs) and Random forests (RF).
+    While RF and GBDT algorithms differ in the way they train the models,
+    they both produce a decision forest as their output.
 
     Uses the Forest Inference Library (FIL) backend for inference.
     """
@@ -107,7 +112,7 @@ class Forest(PipelineableInferenceOperator):
         )
 
     @classmethod
-    def from_config(cls, config: dict) -> "Forest":
+    def from_config(cls, config: dict) -> "PredictForest":
         """Instantiate the class from a dictionary representation.
 
         Expected structure:

--- a/merlin/systems/dag/ops/operator.py
+++ b/merlin/systems/dag/ops/operator.py
@@ -166,6 +166,7 @@ class PipelineableInferenceOperator(InferenceOperator):
         params: dict = None,
         node_id: int = None,
         version: int = 1,
+        backend: str = "python",
     ):
         """
         Export the class object as a config and all related files to the user-defined path.
@@ -200,7 +201,7 @@ class PipelineableInferenceOperator(InferenceOperator):
         node_export_path = pathlib.Path(path) / node_name
         node_export_path.mkdir(parents=True, exist_ok=True)
 
-        config = model_config.ModelConfig(name=node_name, backend="python", platform="op_runner")
+        config = model_config.ModelConfig(name=node_name, backend=backend, platform="op_runner")
 
         config.parameters["operator_names"].string_value = json.dumps([node_name])
 

--- a/merlin/systems/triton/oprunner_model.py
+++ b/merlin/systems/triton/oprunner_model.py
@@ -104,14 +104,15 @@ class TritonPythonModel:
 
                 raw_tensor_tuples = self.runner.execute(inf_df)
 
-                tensors = {
-                    name: (data.get() if hasattr(data, "get") else data)
-                    for name, data in raw_tensor_tuples
-                }
+                output_tensors = []
+                for name, data in raw_tensor_tuples:
+                    if isinstance(data, Tensor):
+                        output_tensors.append(data)
+                    data = data.get() if hasattr(data, "get") else data
+                    tensor = Tensor(name, data)
+                    output_tensors.append(tensor)
 
-                result = [Tensor(name, data) for name, data in tensors.items()]
-
-                responses.append(InferenceResponse(result))
+                responses.append(InferenceResponse(output_tensors))
 
             except Exception:  # pylint: disable=broad-except
                 exc_type, exc_value, exc_traceback = sys.exc_info()

--- a/merlin/systems/triton/oprunner_model.py
+++ b/merlin/systems/triton/oprunner_model.py
@@ -42,11 +42,48 @@ from merlin.systems.dag.ops.operator import InferenceDataFrame
 
 
 class TritonPythonModel:
+    """Model for Triton Python Backend.
+
+    Every Python model must have "TritonPythonModel" as the class name
+    """
+
     def initialize(self, args):
+        """Called only once when the model is being loaded. Allowing
+        the model to initialize any state associated with this model.
+
+        Parameters
+        ----------
+        args : dict
+          Both keys and values are strings. The dictionary keys and values are:
+          * model_config: A JSON string containing the model configuration
+          * model_instance_kind: A string containing model instance kind
+          * model_instance_device_id: A string containing model instance device ID
+          * model_repository: Model repository path
+          * model_version: Model version
+          * model_name: Model name
+        """
         self.model_config = json.loads(args["model_config"])
         self.runner = OperatorRunner(self.model_config)
 
     def execute(self, requests: List[InferenceRequest]) -> List[InferenceResponse]:
+        """Receives a list of pb_utils.InferenceRequest as the only argument. This
+        function is called when an inference is requested for this model. Depending on the
+        batching configuration (e.g. Dynamic Batching) used, `requests` may contain
+        multiple requests. Every Python model, must create one pb_utils.InferenceResponse
+        for every pb_utils.InferenceRequest in `requests`. If there is an error, you can
+        set the error argument when creating a pb_utils.InferenceResponse.
+
+        Parameters
+        ----------
+        requests : list
+          A list of pb_utils.InferenceRequest
+
+        Returns
+        -------
+        list
+          A list of pb_utils.InferenceResponse. The length of this list must
+          be the same as `requests`
+        """
         params = self.model_config["parameters"]
         op_names = json.loads(params["operator_names"]["string_value"])
         first_operator_name = op_names[0]

--- a/tests/unit/systems/fil/test_forest.py
+++ b/tests/unit/systems/fil/test_forest.py
@@ -139,7 +139,7 @@ def test_ensemble(tmpdir):
     config_path = tmpdir / "0_transformworkflow" / "config.pbtxt"
     parsed_config = read_config(config_path)
     assert parsed_config.name == "0_transformworkflow"
-    assert parsed_config.backend == "nvtabular"
+    assert parsed_config.backend == "python"
 
     config_path = tmpdir / "ensemble_model" / "config.pbtxt"
     parsed_config = read_config(config_path)

--- a/tests/unit/systems/fil/test_forest.py
+++ b/tests/unit/systems/fil/test_forest.py
@@ -1,3 +1,18 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 import json
 
 import numpy as np

--- a/tests/unit/systems/fil/test_forest.py
+++ b/tests/unit/systems/fil/test_forest.py
@@ -85,9 +85,9 @@ def test_export(tmpdir):
     output_schema = Schema([ColumnSchema("output__0", dtype=np.float32)])
     _ = PredictForest(model, input_schema).export(tmpdir, input_schema, output_schema, node_id=2)
 
-    config_path = tmpdir / "2_forest" / "config.pbtxt"
+    config_path = tmpdir / "2_predictforest" / "config.pbtxt"
     parsed_config = read_config(config_path)
-    assert parsed_config.name == "2_forest"
+    assert parsed_config.name == "2_predictforest"
     assert parsed_config.backend == "python"
 
     config_path = tmpdir / "2_fil" / "config.pbtxt"
@@ -126,9 +126,9 @@ def test_ensemble(tmpdir):
 
     triton_ens.export(tmpdir)
 
-    config_path = tmpdir / "1_forest" / "config.pbtxt"
+    config_path = tmpdir / "1_predictforest" / "config.pbtxt"
     parsed_config = read_config(config_path)
-    assert parsed_config.name == "1_forest"
+    assert parsed_config.name == "1_predictforest"
     assert parsed_config.backend == "python"
 
     config_path = tmpdir / "1_fil" / "config.pbtxt"

--- a/tests/unit/systems/fil/test_forest.py
+++ b/tests/unit/systems/fil/test_forest.py
@@ -1,0 +1,72 @@
+import json
+
+import numpy as np
+import pytest
+import sklearn.datasets
+import xgboost
+from google.protobuf import text_format
+
+from merlin.schema import ColumnSchema, Schema
+from merlin.systems.dag.ops.fil import Forest
+
+tritonclient = pytest.importorskip("tritonclient")
+import tritonclient.grpc.model_config_pb2 as model_config  # noqa
+
+
+def test_load_from_config(tmpdir):
+    rows = 200
+    num_features = 16
+    X, y = sklearn.datasets.make_regression(
+        n_samples=rows,
+        n_features=num_features,
+        n_informative=num_features // 3,
+        random_state=0,
+    )
+    model = xgboost.XGBRegressor()
+    model.fit(X, y)
+    feature_names = [str(i) for i in range(num_features)]
+    input_schema = Schema([ColumnSchema(col, dtype=np.float32) for col in feature_names])
+    output_schema = Schema([ColumnSchema("output__0", dtype=np.float32)])
+    config = Forest(model, input_schema).export(tmpdir, input_schema, output_schema, node_id=2)
+    node_config = json.loads(config.parameters[config.name].string_value)
+
+    assert json.loads(node_config["output_dict"]) == {
+        "output__0": {"dtype": "float32", "is_list": False, "is_ragged": False}
+    }
+
+    cls = Forest.from_config(node_config)
+    assert cls.fil_model_name == "2_fil"
+
+
+def read_config(config_path):
+    with open(config_path, "rb") as f:
+        config = model_config.ModelConfig()
+        raw_config = f.read()
+        return text_format.Parse(raw_config, config)
+
+
+def test_export(tmpdir):
+    rows = 200
+    num_features = 16
+    X, y = sklearn.datasets.make_regression(
+        n_samples=rows,
+        n_features=num_features,
+        n_informative=num_features // 3,
+        random_state=0,
+    )
+    model = xgboost.XGBRegressor()
+    model.fit(X, y)
+    feature_names = [str(i) for i in range(num_features)]
+    input_schema = Schema([ColumnSchema(col, dtype=np.float32) for col in feature_names])
+    output_schema = Schema([ColumnSchema("output__0", dtype=np.float32)])
+    _ = Forest(model, input_schema).export(tmpdir, input_schema, output_schema, node_id=2)
+
+    config_path = tmpdir / "2_forest" / "config.pbtxt"
+    parsed_config = read_config(config_path)
+    assert parsed_config.name == "2_forest"
+    assert parsed_config.backend == "python"
+
+    config_path = tmpdir / "2_fil" / "config.pbtxt"
+    parsed_config = read_config(config_path)
+    assert parsed_config.name == "2_fil"
+    assert parsed_config.backend == "fil"

--- a/tests/unit/systems/fil/test_forest.py
+++ b/tests/unit/systems/fil/test_forest.py
@@ -126,12 +126,12 @@ def test_ensemble(tmpdir):
 
     config_path = tmpdir / "1_forest" / "config.pbtxt"
     parsed_config = read_config(config_path)
-    assert parsed_config.name == "0_forest"
+    assert parsed_config.name == "1_forest"
     assert parsed_config.backend == "python"
 
     config_path = tmpdir / "1_fil" / "config.pbtxt"
     parsed_config = read_config(config_path)
-    assert parsed_config.name == "0_fil"
+    assert parsed_config.name == "1_fil"
     assert parsed_config.backend == "fil"
 
     config_path = tmpdir / "0_transformworkflow" / "config.pbtxt"


### PR DESCRIPTION
Add `PredictForest` Inference Operator. Wraps the FIL operator added in #110 And uses the python backend and Business Logic Scripting to make requests to the FIL model.

Exporting the Forest operator results in two Triton models:

- One fil backend model
- One python backend model which wraps the fil backend. When a request is made to this model. In the Python runner, we use Business Logic Scripting to create a request to the model with the fil backend that runs inference on the model.

## Example

```python
# export the model data to a model repository directory
from merlin.systems.dag.ops.fil import PredictForest

model = ...  # XGBoost, LightGBM, or cuml/sklearn random forest.
input_schema = ...  # merlin Schema representing input features to the model
ops = feature_names >> PredictForest(model, input_schema)
ensemble = Ensemble(ops, input_schema)
ensemble.export(export_path)


# make a request to the ensemble
from merlin.systems.triton.utils import send_triton_request

outputs_list = ensemble.graph.output_schema.column_names
response = send_triton_request(request, outputs_list, endpoint="triton:8001", triton_model="ensemble_model")
response
```

## Note on GPU usage

I encountered an issue when using GPU with the FIL op + the PredictForest wrapper op. I have been receiving the following error: 

```
failed to open cuda ipc handle
```

A work-around I found was to set the instance group to CPU

```
PredictForest(model, input_schema, instance_group="CPU")
```