### PR TITLE
Fix dtype of multi-hot features' `nnzs` field

### DIFF
--- a/merlin/systems/dag/ops/feast.py
+++ b/merlin/systems/dag/ops/feast.py
@@ -93,7 +93,7 @@ class QueryFeast(PipelineableInferenceOperator):
                     values_name, dtype=feature_dtype, is_list=is_list, is_ragged=is_ragged
                 )
                 output_schema[nnzs_name] = ColumnSchema(
-                    nnzs_name, dtype=feature.dtype, is_list=True, is_ragged=False
+                    nnzs_name, dtype=np.int32, is_list=True, is_ragged=False
                 )
             else:
                 features.append(feature.name)


### PR DESCRIPTION
It shouldn't be the original Feast dtype of the field, it should be an integer type. I think `int32` should be safe here, but we can do something fancier later if it turns out we actually do need `int64` for some cases.