### PR TITLE
Correct FIL export format for sklearn/cuml to treelite checkpoint

### DIFF
--- a/.github/workflows/fil.yml
+++ b/.github/workflows/fil.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Install FIL pip dependencies
         run: |
           python -m pip install xgboost lightgbm sklearn
+          # version of treelite is required to match the version used in Triton
+          python -m pip install treelite==2.3.0 treelite_runtime==2.3.0
       - name: Build
         run: |
           python setup.py develop

--- a/merlin/systems/dag/ops/compat.py
+++ b/merlin/systems/dag/ops/compat.py
@@ -24,6 +24,10 @@ try:
 except ImportError:
     sklearn_ensemble = None
 try:
+    import treelite.sklearn as treelite_sklearn
+except ImportError:
+    treelite_sklearn = None
+try:
     import lightgbm
 except ImportError:
     lightgbm = None

--- a/tests/unit/systems/fil/test_fil.py
+++ b/tests/unit/systems/fil/test_fil.py
@@ -210,6 +210,23 @@ def test_regressor(get_model_fn, get_model_params, tmpdir):
     assert config.output[0].dims == [1]
 
 
+@pytest.mark.parametrize(
+    ["get_model_fn", "expected_model_filename"],
+    [
+        (xgboost_regressor, "xgboost.json"),
+        (lightgbm_regressor, "model.txt"),
+        (sklearn_forest_regressor, "checkpoint.tl"),
+    ],
+)
+def test_model_file(get_model_fn, expected_model_filename, tmpdir):
+    X, y = get_regression_data()
+    model = get_model_fn(X, y)
+    triton_op = fil_op.FIL(model)
+    _ = export_op(tmpdir, triton_op)
+    model_path = pathlib.Path(tmpdir) / "fil" / "1" / expected_model_filename
+    assert model_path.is_file()
+
+
 def test_fil_op_exports_own_config(tmpdir):
     X, y = get_regression_data()
     model = xgboost_train(X, y, objective="reg:squarederror")


### PR DESCRIPTION
Correct FIL export format for sklearn/cuml to treelite checkpoint.

This requires `treelite` and `treelite_runtime` packages and the version must match the triton version to work correctly. 