### PR TITLE
Enable gRPC port to be specified in `run_triton_server` and check if already running

### DIFF
--- a/merlin/systems/triton/utils.py
+++ b/merlin/systems/triton/utils.py
@@ -14,7 +14,7 @@ TRITON_SERVER_PATH = find_executable("tritonserver")
 
 
 @contextlib.contextmanager
-def run_triton_server(modelpath):
+def run_triton_server(modelpath, grpc_host="localhost", grpc_port=8001):
     """This function starts up a Triton server instance and returns a client to it.
 
     Parameters
@@ -28,8 +28,6 @@ def run_triton_server(modelpath):
         The client connected to the Triton server.
 
     """
-    grpc_host = "localhost"
-    grpc_port = 8001
     grpc_url = f"{grpc_host}:{grpc_port}"
 
     with grpcclient.InferenceServerClient(grpc_url) as client:

--- a/merlin/systems/triton/utils.py
+++ b/merlin/systems/triton/utils.py
@@ -28,6 +28,14 @@ def run_triton_server(modelpath):
         The client connected to the Triton server.
 
     """
+    grpc_host = "localhost"
+    grpc_port = 8001
+    grpc_url = f"{grpc_host}:{grpc_port}"
+
+    with grpcclient.InferenceServerClient(grpc_url) as client:
+        if client.is_server_ready():
+            raise RuntimeError(f"Another tritonserver is already running on {grpc_url}")
+
     cmdline = [
         TRITON_SERVER_PATH,
         "--model-repository",
@@ -38,7 +46,7 @@ def run_triton_server(modelpath):
     env["CUDA_VISIBLE_DEVICES"] = "0"
     with subprocess.Popen(cmdline, env=env) as process:
         try:
-            with grpcclient.InferenceServerClient("localhost:8001") as client:
+            with grpcclient.InferenceServerClient(grpc_url) as client:
                 # wait until server is ready
                 for _ in range(60):
                     if process.poll() is not None:

--- a/merlin/systems/triton/utils.py
+++ b/merlin/systems/triton/utils.py
@@ -30,9 +30,12 @@ def run_triton_server(modelpath, grpc_host="localhost", grpc_port=8001):
     """
     grpc_url = f"{grpc_host}:{grpc_port}"
 
-    with grpcclient.InferenceServerClient(grpc_url) as client:
-        if client.is_server_ready():
-            raise RuntimeError(f"Another tritonserver is already running on {grpc_url}")
+    try:
+        with grpcclient.InferenceServerClient(grpc_url) as client:
+            if client.is_server_ready():
+                raise RuntimeError(f"Another tritonserver is already running on {grpc_url}")
+    except tritonclient.utils.InferenceServerException:
+        pass
 
     cmdline = [
         TRITON_SERVER_PATH,

--- a/merlin/systems/triton/utils.py
+++ b/merlin/systems/triton/utils.py
@@ -16,14 +16,26 @@ TRITON_SERVER_PATH = find_executable("tritonserver")
 
 @contextlib.contextmanager
 def run_triton_server(
-    modelpath, grpc_host="localhost", grpc_port=None, backend_config="tensorflow,version=2"
+    model_repository: str,
+    *,
+    grpc_host: str = "localhost",
+    grpc_port: int = 0,
+    backend_config: str = "tensorflow,version=2",
 ):
     """This function starts up a Triton server instance and returns a client to it.
 
     Parameters
     ----------
-    modelpath : string
-        The path to the model to load.
+    model_repository : string
+        The path to the model repository directory.
+    grpc_host : string
+        The host address for the triton gRPC server to bind to.
+    grpc_port : int
+        The port for the triton gRPC server to listen on for requests.
+    backend_config : string
+        A backend-specific configuration.
+        Following the pattern <backend_name>,<setting>=<value>.
+        Where <backend_name> is the name of the backend, such as 'tensorflow'
 
     Yields
     ------
@@ -45,7 +57,7 @@ def run_triton_server(
     cmdline = [
         TRITON_SERVER_PATH,
         "--model-repository",
-        modelpath,
+        model_repository,
         f"--backend-config={backend_config}",
         f"--grpc-port={grpc_port}",
         f"--grpc-address={grpc_host}",

--- a/merlin/systems/triton/utils.py
+++ b/merlin/systems/triton/utils.py
@@ -19,7 +19,7 @@ def run_triton_server(
     model_repository: str,
     *,
     grpc_host: str = "localhost",
-    grpc_port: int = 0,
+    grpc_port: int = 8001,
     backend_config: str = "tensorflow,version=2",
 ):
     """This function starts up a Triton server instance and returns a client to it.
@@ -33,7 +33,7 @@ def run_triton_server(
         Default is localhost.
     grpc_port : int
         The port for the triton gRPC server to listen on for requests.
-        Default is 0. In this case a random available port will be used.
+        Default is 8001.
     backend_config : string
         A backend-specific configuration.
         Following the pattern <backend_name>,<setting>=<value>.

--- a/merlin/systems/triton/utils.py
+++ b/merlin/systems/triton/utils.py
@@ -30,8 +30,10 @@ def run_triton_server(
         The path to the model repository directory.
     grpc_host : string
         The host address for the triton gRPC server to bind to.
+        Default is localhost.
     grpc_port : int
         The port for the triton gRPC server to listen on for requests.
+        Default is 0. In this case a random available port will be used.
     backend_config : string
         A backend-specific configuration.
         Following the pattern <backend_name>,<setting>=<value>.

--- a/tests/unit/examples/test_serving_an_xgboost_model_with_merlin_systems.py
+++ b/tests/unit/examples/test_serving_an_xgboost_model_with_merlin_systems.py
@@ -34,5 +34,5 @@ def test_example_serving_xgboost(tb):
     )
     tb.execute_cell(list(range(0, 14)))
 
-    with run_triton_server("ensemble"):
+    with run_triton_server("ensemble", grpc_port=8001):
         tb.execute_cell(list(range(14, NUM_OF_CELLS)))


### PR DESCRIPTION
## Goal

Improve the reliability of local dev and CI testing using triton.

## Motivation

When a  `tritonserver` process is already running on the port we would like to bind to - the tests relying on the `run_triton_server` helper fail with an unexpected error (complaining that the model is not loaded for example). 

Enabling the gRPC server to listen on a random port allows us to run multiple ensemble tests at the same time (GPU resources permitting).

## Details

This PR will:

- Add `grpc_port`, `grpc_host`, and `backend_config` parameters to `run_triton_server`
  - Default is set to `8001`. The same  as before. If 0 is provided,a random free port will be used.
- Add a check to see if a tritonserver process is already running on the desired port and raises an exception if there is one.