### PR TITLE
Load models from a model registry rather than path

### DIFF
--- a/merlin/systems/dag/ops/operator.py
+++ b/merlin/systems/dag/ops/operator.py
@@ -2,10 +2,11 @@ import inspect
 import json
 import os
 import pathlib
-import requests
 from abc import abstractclassmethod, abstractmethod
 from shutil import copyfile
 from typing import Optional
+
+import requests
 
 # this needs to be before any modules that import protobuf
 os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
@@ -131,8 +132,8 @@ class InferenceOperator(BaseOperator):
         Loads the InferenceOperator from an MLflow Model Registry.
 
         This only works for operators that extend this base class and accept a model path
-        as an argument to its __init__ function, such as PredictTensorflow. A counter example would be
-        TransformWorkflow, which does not load a model.
+        as an argument to its __init__ function, such as PredictTensorflow. A counter example would
+        be TransformWorkflow, which does not load a model.
 
         Parameters
         ----------
@@ -149,27 +150,30 @@ class InferenceOperator(BaseOperator):
             New node for Ensemble graph.
         """
 
-        # validate that we have a model_or_path argument. This is a total hack and perhaps a smell that all inference operators
-        # should accept a model_or_path, or at least we introduce another layer of base class that does.
+        # validate that we have a model_or_path argument. This is a total hack and perhaps a smell
+        # that all inference operators should accept a model_or_path, or at least we introduce
+        # another layer of base class that does.
         if "model_or_path" not in inspect.signature(cls.__init__).parameters:
             raise TypeError(
-                "from_mlflow_registry only works for Operators that accept a model path as parameter called `model_or_path`."
+                "from_mlflow_registry only works for Operators that accept a model path as\n"
+                + "a parameter called `model_or_path`."
             )
-        tracking_uri = mlflow_tracking_uri or os.environ.get("MLFLOW_TRACKING_URI")
 
+        tracking_uri = mlflow_tracking_uri or os.environ.get("MLFLOW_TRACKING_URI")
         if tracking_uri is None:
             raise ValueError(
-                "You must specify an mlflow tracking URi or set it in the environment variable MLFLOW_TRACKING_URI"
+                "You must specify an mlflow tracking URI or set it in the environment variable "
+                + "MLFLOW_TRACKING_URI"
             )
-
+        tracking_uri = tracking_uri.rstrip("/")
         mv = requests.get(
-            f"{tracking_uri.rstrip('/')}/ajax-api/2.0/preview/mlflow/model-versions/get-download-uri",
+            f"{tracking_uri}/ajax-api/2.0/preview/mlflow/model-versions/get-download-uri",
             params={"name": name, "version": version},
         )
 
         if mv.status_code != 200:
             raise ValueError(
-                f"Could not find a Model Verison for model {name} with version {version}."
+                f"Could not find a Model Version for model {name} with version {version}."
             )
         model_path = mv.json()["artifact_uri"]
         return cls(model_path, **kwargs)

--- a/merlin/systems/dag/ops/operator.py
+++ b/merlin/systems/dag/ops/operator.py
@@ -150,7 +150,7 @@ class InferenceOperator(BaseOperator):
         # another layer of base class that does.
         if "model_or_path" not in inspect.signature(cls.__init__).parameters:
             raise TypeError(
-                "from_mlflow_registry only works for Operators that accept a model path as\n"
+                "from_model_registry only works for Operators that accept a model path as\n"
                 + "a parameter called `model_or_path`."
             )
 

--- a/merlin/systems/dag/ops/operator.py
+++ b/merlin/systems/dag/ops/operator.py
@@ -1,4 +1,3 @@
-import inspect
 import json
 import os
 import pathlib
@@ -126,11 +125,7 @@ class InferenceOperator(BaseOperator):
     @classmethod
     def from_model_registry(cls, registry: ModelRegistry, **kwargs) -> "InferenceOperator":
         """
-        Loads the InferenceOperator from an MLflow Model Registry.
-
-        This only works for operators that extend this base class and accept a model path
-        as an argument to its __init__ function, such as PredictTensorflow. A counter example would
-        be TransformWorkflow, which does not load a model.
+        Loads the InferenceOperator from the provided ModelRegistry.
 
         Parameters
         ----------
@@ -145,16 +140,26 @@ class InferenceOperator(BaseOperator):
             New node for Ensemble graph.
         """
 
-        # validate that we have a model_or_path argument. This is a total hack and perhaps a smell
-        # that all inference operators should accept a model_or_path, or at least we introduce
-        # another layer of base class that does.
-        if "model_or_path" not in inspect.signature(cls.__init__).parameters:
-            raise TypeError(
-                "from_model_registry only works for Operators that accept a model path as\n"
-                + "a parameter called `model_or_path`."
-            )
+        return cls.from_path(registry.get_artifact_uri(), **kwargs)
 
-        return cls(registry.get_artifact_uri(), **kwargs)
+    @classmethod
+    def from_path(cls, path, **kwargs) -> "InferenceOperator":
+        """
+        Loads the InferenceOperator from the path where it was exported after training.
+
+        Parameters
+        ----------
+        path : str
+            Path to the exported model.
+        **kwargs
+            Other kwargs to pass to your InferenceOperator's constructor.
+
+        Returns
+        -------
+        InferenceOperator
+            New node for Ensemble graph.
+        """
+        raise NotImplementedError(f"{cls.__name__} operators cannot be instantiated with a path.")
 
 
 class PipelineableInferenceOperator(InferenceOperator):

--- a/merlin/systems/dag/ops/tensorflow.py
+++ b/merlin/systems/dag/ops/tensorflow.py
@@ -107,6 +107,10 @@ class PredictTensorflow(InferenceOperator):
 
         return self._export_model(self.model, node_name, node_export_path, version=version)
 
+    @classmethod
+    def from_path(cls, path, **kwargs):
+        return cls.__init__(path, **kwargs)
+
     def compute_input_schema(
         self,
         root_schema: Schema,

--- a/merlin/systems/model_registry.py
+++ b/merlin/systems/model_registry.py
@@ -1,9 +1,9 @@
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 import requests
 
 
-class ModelRegistry:
+class ModelRegistry(ABC):
     """
     The ModelRegistry class is used to find model paths that will be imported into an
     InferenceOperator.
@@ -47,7 +47,7 @@ class MLFlowModelRegistry(ModelRegistry):
         self.version = version
         self.tracking_uri = tracking_uri.rstrip("/")
 
-    def artifact_uri(self) -> str:
+    def get_artifact_uri(self) -> str:
         mv = requests.get(
             f"{self.tracking_uri}/ajax-api/2.0/preview/mlflow/model-versions/get-download-uri",
             params={"name": self.name, "version": self.version},

--- a/merlin/systems/model_registry.py
+++ b/merlin/systems/model_registry.py
@@ -1,0 +1,61 @@
+from abc import abstractmethod
+
+import requests
+
+
+class ModelRegistry:
+    """
+    The ModelRegistry class is used to find model paths that will be imported into an
+    InferenceOperator.
+
+    To implement your own ModelRegistry subclass, the only method that must be implemented is
+    `get_artifact_uri`, which must return a string indicating the model's export path.
+
+    ```python
+    PredictTensorflow.from_model_registry(
+        MyModelRegistry("model_name", "model_version")
+    )
+    ```
+    """
+
+    @abstractmethod
+    def get_artifact_uri(self) -> str:
+        """
+        This returns the URI of the model artifact.
+        """
+
+
+class MLFlowModelRegistry(ModelRegistry):
+    def __init__(self, name: str, version: str, tracking_uri: str):
+        """
+        Fetches the model path from an mlflow model registry.
+
+        Note that this will return a relative path if you did not configure your mlflow
+        experiment's `artifact_location` to be an absolute path.
+
+        Parameters
+        ----------
+        name : str
+            Name of the model in the mlflow registry.
+        version : str
+            Version of the model to use.
+        tracking_uri : str
+            Base URI of the mlflow tracking server. If running locally, this would likely be
+            http://localhost:5000
+        """
+        self.name = name
+        self.version = version
+        self.tracking_uri = tracking_uri.rstrip("/")
+
+    def artifact_uri(self) -> str:
+        mv = requests.get(
+            f"{self.tracking_uri}/ajax-api/2.0/preview/mlflow/model-versions/get-download-uri",
+            params={"name": self.name, "version": self.version},
+        )
+
+        if mv.status_code != 200:
+            raise ValueError(
+                f"Could not find a Model Version for model {self.name} with version {self.version}."
+            )
+        model_path = mv.json()["artifact_uri"]
+        return model_path

--- a/tests/unit/systems/test_inference_ops.py
+++ b/tests/unit/systems/test_inference_ops.py
@@ -15,14 +15,15 @@
 #
 import os
 import pathlib
+from inspect import signature
 
 import pytest
 import requests
 
-from inspect import signature
-
 # this needs to be before any modules that import protobuf
 os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
+
+from unittest.mock import MagicMock, patch  # noqa
 
 from google.protobuf import text_format  # noqa
 
@@ -31,8 +32,6 @@ from merlin.systems.dag.ops.operator import InferenceOperator  # noqa
 from merlin.systems.dag.ops.tensorflow import PredictTensorflow  # noqa
 from nvtabular import Workflow  # noqa
 from nvtabular import ops as wf_ops  # noqa
-
-from unittest.mock import MagicMock, patch
 
 ensemble = pytest.importorskip("merlin.systems.dag.ensemble")
 model_config = pytest.importorskip("tritonclient.grpc.model_config_pb2")

--- a/tests/unit/systems/test_model_registry.py
+++ b/tests/unit/systems/test_model_registry.py
@@ -13,4 +13,4 @@ def test_mlflowregistry(mock_req, tmpdir):
     mock_req.return_value = resp
 
     registry = MLFlowModelRegistry("name", "version", "http://host:123")
-    assert registry.artifact_uri() == tmpdir
+    assert registry.get_artifact_uri() == tmpdir

--- a/tests/unit/systems/test_model_registry.py
+++ b/tests/unit/systems/test_model_registry.py
@@ -1,0 +1,16 @@
+from unittest.mock import patch
+
+import requests
+
+from merlin.systems.model_registry import MLFlowModelRegistry
+
+
+@patch("requests.get")
+def test_mlflowregistry(mock_req, tmpdir):
+    resp = requests.models.Response()
+    resp.status_code = 200
+    resp.json = lambda: {"artifact_uri": tmpdir}
+    mock_req.return_value = resp
+
+    registry = MLFlowModelRegistry("name", "version", "http://host:123")
+    assert registry.artifact_uri() == tmpdir


### PR DESCRIPTION
This gives the option to load models into `PredictTensorflow` from any model registry, and includes an implementation for mlflow.

Example usage:

```python
PredictTensorflow.from_model_registry(
    MLFlowModelRegistry("my_production_model", "version-1", "http://tracking-uri")
)
```

The implementation simply gets the path to the model and uses it to call `PredictTensorflow`'s init method.

One issue that I ran into is that it seems like it would be nice to have this available for all implementations of `InferenceOperator`, but not all of those implementations accept a model path as an input - in fact only `PredictTensorflow` does. `FIL` only takes a model input as an input, and `TransformWorkflow` doesn't use a model at all.

I came up with a questionable solution of looking for `model_or_path` in the signature of the implementation class's `__init__` method (in fact, it should be the first argument to that method). I'd love to hear a suggestion of a better way to do this.