### PR TITLE
Pass model kwargs through to operator from_config methods

### DIFF
--- a/merlin/systems/dag/op_runner.py
+++ b/merlin/systems/dag/op_runner.py
@@ -23,6 +23,7 @@ class OperatorRunner:
     def __init__(
         self,
         config,
+        *,
         model_repository="./",
         model_version=1,
         model_name=None,

--- a/merlin/systems/dag/op_runner.py
+++ b/merlin/systems/dag/op_runner.py
@@ -18,7 +18,16 @@ import json
 
 
 class OperatorRunner:
-    def __init__(self, config, repository="./", version=1, kind=""):
+    """Runner for collection of operators in one triton model."""
+
+    def __init__(
+        self,
+        config,
+        model_repository="./",
+        model_version=1,
+        model_name=None,
+    ):
+        """Instantiate an OperatorRunner"""
         operator_names = self.fetch_json_param(config, "operator_names")
         op_configs = [self.fetch_json_param(config, op_name) for op_name in operator_names]
 
@@ -30,14 +39,21 @@ class OperatorRunner:
             op_module = importlib.import_module(module_name)
             op_class = getattr(op_module, class_name)
 
-            operator = op_class.from_config(op_config)
+            operator = op_class.from_config(
+                op_config,
+                model_repository=model_repository,
+                model_name=model_name,
+                model_version=model_version,
+            )
             self.operators.append(operator)
 
     def execute(self, tensors):
+        """Run transform on multiple operators"""
         for operator in self.operators:
             tensors = operator.transform(tensors)
         return tensors
 
     def fetch_json_param(self, model_config, param_name):
+        """Extract JSON value from model config parameters"""
         string_value = model_config["parameters"][param_name]["string_value"]
         return json.loads(string_value)

--- a/merlin/systems/dag/ops/faiss.py
+++ b/merlin/systems/dag/ops/faiss.py
@@ -59,7 +59,7 @@ class QueryFaiss(PipelineableInferenceOperator):
         super().__init__()
 
     @classmethod
-    def from_config(cls, config: dict) -> "QueryFaiss":
+    def from_config(cls, config: dict, **kwargs) -> "QueryFaiss":
         """
         Instantiate a class object given a config.
 

--- a/merlin/systems/dag/ops/feast.py
+++ b/merlin/systems/dag/ops/feast.py
@@ -198,7 +198,7 @@ class QueryFeast(PipelineableInferenceOperator):
         return self.input_schema
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config, **kwargs) -> "QueryFeast":
         """Create the operator from a config."""
         parameters = json.loads(config.get("params", ""))
         entity_id = parameters["entity_id"]

--- a/merlin/systems/dag/ops/fil.py
+++ b/merlin/systems/dag/ops/fil.py
@@ -67,6 +67,7 @@ class PredictForest(PipelineableInferenceOperator):
         self.backend = backend
         self.input_schema = input_schema
         self._fil_model_name = None
+        super().__init__()
 
     def compute_output_schema(
         self,
@@ -112,7 +113,7 @@ class PredictForest(PipelineableInferenceOperator):
         )
 
     @classmethod
-    def from_config(cls, config: dict) -> "PredictForest":
+    def from_config(cls, config: dict, **kwargs) -> "PredictForest":
         """Instantiate the class from a dictionary representation.
 
         Expected structure:

--- a/merlin/systems/dag/ops/operator.py
+++ b/merlin/systems/dag/ops/operator.py
@@ -171,14 +171,18 @@ class PipelineableInferenceOperator(InferenceOperator):
 
     @classmethod
     @abstractmethod
-    def from_config(cls, config: dict):
+    def from_config(cls, config: dict, **kwargs):
         """
         Instantiate a class object given a config.
 
         Parameters
         ----------
         config : dict
-
+        **kwargs
+          contains the following:
+            * model_repository: Model repository path
+            * model_version: Model version
+            * model_name: Model name
 
         Returns
         -------

--- a/merlin/systems/dag/ops/session_filter.py
+++ b/merlin/systems/dag/ops/session_filter.py
@@ -50,7 +50,7 @@ class FilterCandidates(PipelineableInferenceOperator):
         super().__init__()
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config, **kwargs) -> "FilterCandidates":
         """
         Instantiate a class object given a config.
 

--- a/merlin/systems/dag/ops/softmax_sampling.py
+++ b/merlin/systems/dag/ops/softmax_sampling.py
@@ -37,7 +37,7 @@ class SoftmaxSampling(PipelineableInferenceOperator):
         super().__init__()
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config, **kwargs) -> "SoftmaxSampling":
         """Load operator and properties from Triton config"""
         parameters = json.loads(config.get("params", ""))
         relevance_col = parameters["relevance_col"]

--- a/merlin/systems/dag/ops/unroll_features.py
+++ b/merlin/systems/dag/ops/unroll_features.py
@@ -36,7 +36,7 @@ class UnrollFeatures(PipelineableInferenceOperator):
         super().__init__()
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config, **kwargs) -> "UnrollFeatures":
         """Load operator and properties from Triton config"""
         parameters = json.loads(config.get("params", ""))
         candidate_col = parameters["item_id_col"]

--- a/tests/unit/systems/utils/ops.py
+++ b/tests/unit/systems/utils/ops.py
@@ -36,5 +36,5 @@ class PlusTwoOp(inf_op.PipelineableInferenceOperator):
         return column_mapping
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config, **kwargs):
         return PlusTwoOp()


### PR DESCRIPTION
Passing model kwargs (model_repository, model_name, model_version) through to operator `from_config` methods when used in an `OperatorRunner`.

## Motivation

This enables operators to use the location of the model repository to load artifacts that may be required for the operator to run. For example, a serialized model saved alongside the model conifg (or in the model version directory).  

Intended to be used by the Implict operator in #134 . We could also update the QueryFaiss operator to load the index from a relative path too instead of relying on a path in the model config. This would make the model repository self-contained.