### PR TITLE
install more libraries in test environment

### DIFF
--- a/requirements-test-cpu.txt
+++ b/requirements-test-cpu.txt
@@ -6,3 +6,4 @@ tensorflow<=2.9.0
 treelite==2.4.0
 treelite_runtime==2.4.0
 torch~=1.12
+lightgbm==3.3.2

--- a/requirements-test-cpu.txt
+++ b/requirements-test-cpu.txt
@@ -1,4 +1,8 @@
 -r requirements-test.txt
 
+merlin-models>=0.6.0
 faiss-cpu==1.7.2
 tensorflow<=2.9.0
+treelite==2.4.0
+treelite_runtime==2.4.0
+torch~=1.12

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -15,7 +15,6 @@ testbook==0.4.2
 # packages necessary to run tests and push PRs
 feast==0.19.4
 xgboost==1.6.1
-lightgbm==3.3.2
 
 # TODO: do we need more of these?
 # https://github.com/NVIDIA-Merlin/Merlin/blob/a1cc48fe23c4dfc627423168436f26ef7e028204/ci/dockerfile.ci#L13-L18

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -15,6 +15,7 @@ testbook==0.4.2
 # packages necessary to run tests and push PRs
 feast==0.19.4
 xgboost==1.6.1
+lightgbm==3.3.2
 
 # TODO: do we need more of these?
 # https://github.com/NVIDIA-Merlin/Merlin/blob/a1cc48fe23c4dfc627423168436f26ef7e028204/ci/dockerfile.ci#L13-L18

--- a/tox.ini
+++ b/tox.ini
@@ -14,13 +14,13 @@ commands =
 ; Runs all CPU-based tests. NOTE: if you are using an M1 mac, this will fail. You need to
 ; change the tensorflow dependency to `tensorflow-macos` in requirements-test-cpu.txt.
 deps = -rrequirements-test-cpu.txt
-commands = python -m pytest --cov-report term --cov=merlin -rxs tests/unit/
+commands = python -m pytest --cov-report term --cov=merlin -rxs tests/unit/systems
 
 [testenv:test-gpu]
 ; Runs in: Internal Jenkins
 ; Runs GPU-based tests. This is not used yet.
 deps = -rrequirements-test-gpu.txt
-commands = python -m pytest --cov-report term --cov=merlin -rxs tests/unit/
+commands = python -m pytest --cov-report term --cov=merlin -rxs tests/unit/systems
 
 [testenv:lint]
 ; Runs in: Github Actions


### PR DESCRIPTION
* install merlin-models, lightgbm, and some other reuirements for cpu environments
* only run the tests in systems/unit (exclude the example tests)

Now the only tests that are skipped are the ones that depend on triton (and the notebooks).