### PR TITLE
(WIP) Switch ragged multi-hot columns with two Triton arrays to a single `ColumnSchema`

### DIFF
--- a/tests/unit/systems/ops/feast/test_op.py
+++ b/tests/unit/systems/ops/feast/test_op.py
@@ -83,8 +83,7 @@ def test_feast_transform(prefix, is_ragged):
 
         # names of the features with prefix/suffix
         feature_name = f"{prefix}_feature" if prefix else "feature"
-        feature_mh_1 = f"{prefix}_mh_feature_1" if prefix else "mh_feature_1"
-        feature_mh_2 = f"{prefix}_mh_feature_2" if prefix else "mh_feature_2"
+        feature_mh = f"{prefix}_mh_feature" if prefix else "mh_feature"
 
         input_schema = Schema(
             [ColumnSchema("feature"), ColumnSchema("mh_feature", is_list=True, is_ragged=True)]
@@ -92,8 +91,7 @@ def test_feast_transform(prefix, is_ragged):
         output_schema = Schema(
             [
                 ColumnSchema(feature_name),
-                ColumnSchema(feature_mh_1, is_list=True, is_ragged=is_ragged),
-                ColumnSchema(feature_mh_2, is_list=True, is_ragged=is_ragged),
+                ColumnSchema(feature_mh, is_list=True, is_ragged=is_ragged),
             ]
         )
 
@@ -114,5 +112,5 @@ def test_feast_transform(prefix, is_ragged):
         resp = feast_op.transform(df)
         assert resp["entity_id"] == [1]
         assert resp[feature_name] == np.array([[1.0]])
-        assert np.all(resp[feature_mh_1] == np.array([[1.0], [2.0], [3.0]]))
-        assert resp[feature_mh_2] == np.array([[3.0]])
+        assert np.all(resp[feature_mh + "_1"] == np.array([[1.0], [2.0], [3.0]]))
+        assert resp[feature_mh + "_2"] == np.array([[3.0]])


### PR DESCRIPTION
Depends on #170.

This PR aims to clarify how ragged multi-hot columns that are stored in `values`/`offsets` format relate to Merlin schemas. Since the two arrays are a detail of the storage format and form one "logical" column together, this PR aims to standardize on a single `ColumnSchema`. This will work better with the graph construction code, so that the user-facing API only involves a schema for `col_name` and doesn't rely on knowing about `col_name_1` and `col_name_2`.

Operators that need updates:
- [x] QueryFeast
- [ ] PredictTensorflow
- [ ] FilterCandidates?