### PR TITLE
feast should return np.float32 not np.float by default

### DIFF
--- a/merlin/systems/dag/ops/feast.py
+++ b/merlin/systems/dag/ops/feast.py
@@ -12,10 +12,10 @@ from merlin.systems.dag.ops.operator import InferenceDataFrame, PipelineableInfe
 feast_2_numpy = {
     ValueType.INT64: (np.int64, False, False),
     ValueType.INT32: (np.int32, False, False),
-    ValueType.FLOAT: (np.float, False, False),
+    ValueType.FLOAT: (np.float32, False, False),
     ValueType.INT64_LIST: (np.int64, True, True),
     ValueType.INT32_LIST: (np.int32, True, True),
-    ValueType.FLOAT_LIST: (np.float, True, True),
+    ValueType.FLOAT_LIST: (np.float32, True, True),
 }
 
 


### PR DESCRIPTION
A potential solution for https://github.com/NVIDIA-Merlin/systems/issues/177 (still to be verified).

We return `np.float` which is a deprecated alias for `np.float64`. However, when we infer the input schemas in `PredictTensorflow`, continuously valued model inputs are `np.float32`, thus we get a schema mis-match when we chain QueryFeast into PredictTensorflow.