### PR TITLE
add test for QueryFeast.from_feature_view

### DIFF
--- a/merlin/systems/dag/ops/feast.py
+++ b/merlin/systems/dag/ops/feast.py
@@ -37,6 +37,7 @@ class QueryFeast(PipelineableInferenceOperator):
         column: str,
         output_prefix: str = None,
         include_id: bool = False,
+        suffix_int: int = 1,
     ):
         """
         Allows for the creation of a QueryFeast operator from already created Feast artifacts.
@@ -55,6 +56,9 @@ class QueryFeast(PipelineableInferenceOperator):
             A column prefix that can be added to each output column, by default None
         include_id : bool, optional
             A boolean to decide to include the input column in output, by default False
+        suffix_int : int, optional
+            For multi-hot columns, we will use this number for the feature value(s) and
+            `suffix_int + 1` for the nnz column.
 
         Returns
         -------
@@ -87,8 +91,8 @@ class QueryFeast(PipelineableInferenceOperator):
             if is_list:
                 mh_features.append(feature.name)
 
-                values_name = cls._prefixed_name(output_prefix, f"{feature.name}_1")
-                nnzs_name = cls._prefixed_name(output_prefix, f"{feature.name}_2")
+                values_name = cls._prefixed_name(output_prefix, f"{feature.name}_{suffix_int}")
+                nnzs_name = cls._prefixed_name(output_prefix, f"{feature.name}_{suffix_int+1}")
                 output_schema[values_name] = ColumnSchema(
                     values_name, dtype=feature_dtype, is_list=is_list, is_ragged=is_ragged
                 )
@@ -118,7 +122,7 @@ class QueryFeast(PipelineableInferenceOperator):
             output_schema,
             include_id=include_id,
             output_prefix=output_prefix or "",
-            suffix_int=1,
+            suffix_int=suffix_int,
         )
 
     def __init__(

--- a/tests/unit/systems/ops/feast/test_op.py
+++ b/tests/unit/systems/ops/feast/test_op.py
@@ -58,7 +58,7 @@ def test_feast_config_round_trip(tmpdir):
         qf_init.assert_called_with(*args)
 
 
-@pytest.mark.parametrize("suffix_int", [1, 2, 3])
+@pytest.mark.parametrize("suffix_int", [1, 2])
 def test_feast_from_feature_view(tmpdir, suffix_int):
 
     with patch("feast.FeatureStore.__init__", MagicMock(return_value=None)), patch(
@@ -129,7 +129,12 @@ def test_feast_from_feature_view(tmpdir, suffix_int):
         )
 
         feast_op: QueryFeast = QueryFeast.from_feature_view(
-            fs, "item_features", "item_id", output_prefix="prefix", include_id=True
+            fs,
+            "item_features",
+            "item_id",
+            output_prefix="prefix",
+            include_id=True,
+            suffix_int=suffix_int,
         )
 
         assert feast_op.input_schema == expected_input_schema

--- a/tests/unit/systems/ops/feast/test_op.py
+++ b/tests/unit/systems/ops/feast/test_op.py
@@ -30,7 +30,7 @@ def test_feast_config_round_trip(tmpdir):
     # These must be done in a context manager so we don't modify the classes globally and
     # affect other tests.
     with patch("feast.FeatureStore.__init__", MagicMock(return_value=None)), patch(
-        "merlin.systems.dag.ops.feast.__init__", MagicMock(return_value=None)
+        "merlin.systems.dag.ops.feast.QueryFeast", MagicMock(side_effect=QueryFeast)
     ) as qf_init:
 
         # Define the args & kwargs. We want to ensure the round-tripped version uses these same
@@ -44,26 +44,28 @@ def test_feast_config_round_trip(tmpdir):
             ["mh_features"],
             input_schema,
             output_schema,
+            True,  # include_id
+            "prefix",  # output_prefix
+            1,  # suffix_int
         ]
-        kwargs = {"include_id": True, "output_prefix": "prefix"}
-        feast_op = QueryFeast(*args, **kwargs)
+        feast_op = QueryFeast(*args)
 
         created_config = feast_op.export(tmpdir + "/export_path/", input_schema, output_schema)
         created_config_dict = json.loads(created_config.parameters["queryfeast"].string_value)
 
         # now mock the QueryFeast constructor so we can inspect its arguments.
         QueryFeast.from_config(created_config_dict)
-        assert qf_init.called_with(*args, **kwargs)
+        qf_init.assert_called_with(*args)
 
 
 def test_feast_from_feature_view(tmpdir):
 
-    input_schema = Schema()
-    output_schema = Schema()
-
     with patch("feast.FeatureStore.__init__", MagicMock(return_value=None)), patch(
         "feast.feature_store.Registry.__init__", MagicMock(return_value=None)
-    ), patch("merlin.systems.dag.ops.feast.__init__", MagicMock(return_value=None)) as qf_init:
+    ), patch(
+        "merlin.systems.dag.ops.feast.QueryFeast",
+        MagicMock(side_effect=QueryFeast),
+    ) as qf_init:
         input_source = feast.FileSource(
             path=tmpdir,
             event_timestamp_column="datetime",
@@ -92,23 +94,11 @@ def test_feast_from_feature_view(tmpdir):
         fs.get_feature_view = MagicMock(return_value=feature_view)
         fs._registry.get_feature_view = MagicMock(return_value=feature_view)
 
-        # # Define the args & kwargs. We want to ensure the round-tripped version uses these same
-        # # arguments.
-        args = [
-            "zzz",
-            "item_id",
-            "item_features",
-            "item_id",
-            ["int_feature", "float_feature", "int_list_feature", "float_list_feature"],
-            [],
-            input_schema,
-            output_schema,
-        ]
-        kwargs = {"include_id": False, "output_prefix": "prefix"}
-        feast_op = QueryFeast.from_feature_view(
-            fs, "item_features", "item_id", output_prefix="prefix", include_id=False
+        expected_input_schema = Schema(
+            column_schemas=[ColumnSchema(name="item_id", dtype=np.int32)]
         )
 
+        # The expected output is all of the feature columns plus the item_id column
         expected_output_schema = Schema(
             column_schemas=[
                 ColumnSchema(name="prefix_int_feature", dtype=np.int32),
@@ -128,14 +118,29 @@ def test_feast_from_feature_view(tmpdir):
                     dtype=np.int32,
                     is_list=True,
                 ),
+                ColumnSchema(name="item_id", dtype=np.int32),
             ]
         )
-        assert feast_op.input_schema == Schema(
-            column_schemas=[ColumnSchema(name="item_id", dtype=np.int32)]
+
+        feast_op: QueryFeast = QueryFeast.from_feature_view(
+            fs, "item_features", "item_id", output_prefix="prefix", include_id=True
         )
+
+        assert feast_op.input_schema == expected_input_schema
         assert feast_op.output_schema.column_schemas == expected_output_schema.column_schemas
 
-        assert qf_init.called_with(*args, **kwargs)
+        args = [
+            "repo_path",
+            "item_id",
+            "item_features",
+            "item_id",
+            ["int_feature", "float_feature"],
+            ["int_list_feature", "float_list_feature"],
+            expected_input_schema,
+            expected_output_schema,
+        ]
+        kwargs = {"include_id": True, "output_prefix": "prefix", "suffix_int": 1}
+        qf_init.assert_called_with(*args, **kwargs)
 
 
 @pytest.mark.parametrize("is_ragged", [True, False])

--- a/tests/unit/systems/ops/feast/test_op.py
+++ b/tests/unit/systems/ops/feast/test_op.py
@@ -127,7 +127,7 @@ def test_feast_from_feature_view(tmpdir):
         )
 
         assert feast_op.input_schema == expected_input_schema
-        assert feast_op.output_schema.column_schemas == expected_output_schema.column_schemas
+        assert feast_op.output_schema == expected_output_schema
 
         args = [
             "repo_path",

--- a/tests/unit/systems/ops/feast/test_op.py
+++ b/tests/unit/systems/ops/feast/test_op.py
@@ -58,7 +58,8 @@ def test_feast_config_round_trip(tmpdir):
         qf_init.assert_called_with(*args)
 
 
-def test_feast_from_feature_view(tmpdir):
+@pytest.mark.parametrize("suffix_int", [1, 2, 3])
+def test_feast_from_feature_view(tmpdir, suffix_int):
 
     with patch("feast.FeatureStore.__init__", MagicMock(return_value=None)), patch(
         "feast.feature_store.Registry.__init__", MagicMock(return_value=None)
@@ -104,17 +105,22 @@ def test_feast_from_feature_view(tmpdir):
                 ColumnSchema(name="prefix_int_feature", dtype=np.int32),
                 ColumnSchema(name="prefix_float_feature", dtype=np.float32),
                 ColumnSchema(
-                    name="prefix_int_list_feature_1", dtype=np.int32, is_list=True, is_ragged=True
+                    name=f"prefix_int_list_feature_{suffix_int}",
+                    dtype=np.int32,
+                    is_list=True,
+                    is_ragged=True,
                 ),
-                ColumnSchema(name="prefix_int_list_feature_2", dtype=np.int32, is_list=True),
                 ColumnSchema(
-                    name="prefix_float_list_feature_1",
+                    name=f"prefix_int_list_feature_{suffix_int+1}", dtype=np.int32, is_list=True
+                ),
+                ColumnSchema(
+                    name=f"prefix_float_list_feature_{suffix_int}",
                     dtype=np.float32,
                     is_list=True,
                     is_ragged=True,
                 ),
                 ColumnSchema(
-                    name="prefix_float_list_feature_2",
+                    name=f"prefix_float_list_feature_{suffix_int+1}",
                     dtype=np.int32,
                     is_list=True,
                 ),
@@ -139,7 +145,7 @@ def test_feast_from_feature_view(tmpdir):
             expected_input_schema,
             expected_output_schema,
         ]
-        kwargs = {"include_id": True, "output_prefix": "prefix", "suffix_int": 1}
+        kwargs = {"include_id": True, "output_prefix": "prefix", "suffix_int": suffix_int}
         qf_init.assert_called_with(*args, **kwargs)
 
 


### PR DESCRIPTION
Adds a regression test for the bug fix in https://github.com/NVIDIA-Merlin/systems/pull/178

I also caught an error with how the  `assert_called_with` method was used on the `QueryFeast` mock in another test and fixed it.