### PR TITLE
Required changes to get Rank example test passing

### DIFF
--- a/examples/Serving-Ranking-Models-With-Merlin-Systems.ipynb
+++ b/examples/Serving-Ranking-Models-With-Merlin-Systems.ipynb
@@ -1049,9 +1049,11 @@
     "\n",
     "inputs = convert_df_to_triton_input(workflow.input_schema.column_names, batch, grpcclient.InferInput)\n",
     "\n",
+    "output_cols = ensemble.graph.output_schema.column_names\n",
+    "\n",
     "outputs = [\n",
     "    grpcclient.InferRequestedOutput(col)\n",
-    "    for col in ensemble.graph.output_schema.column_names\n",
+    "    for col in output_cols\n",
     "]"
    ]
   },


### PR DESCRIPTION
With new updates to tritonserver and cudf, the current example was failing to run. This seems to have to do with, lack of support for running tritonserver as a subprocess within the testbooks subprocess for executing the notebook. In order to fix this a couple of changes had to be made.

1. Add output_cols variable to the notebook: necessary because testbooks has a hard time creating the json serialization for the ensemble object. All we need is the list of output columns. This lets us use the testbooks.ref to pull out that list.

2. Refactor how we execute the run ensemble on triton command: Need to remove from within the context of the notebook to allow correct execution to occur.