### PR TITLE
add testenv to run merlin tests

### DIFF
--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -2,3 +2,5 @@ feast<=0.20.0
 faiss-gpu
 pytest
 pytest-cov
+dask>=2022.3.0
+distributed>=2022.3.0

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,8 +1,4 @@
--r requirements.txt
 feast<=0.20.0
 faiss-gpu
 pytest
 pytest-cov
-git+https://github.com/NVIDIA-Merlin/core.git
-git+https://github.com/NVIDIA-Merlin/NVTabular.git
-git+https://github.com/NVIDIA-Merlin/models.git

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -3,3 +3,6 @@ feast<=0.20.0
 faiss-gpu
 pytest
 pytest-cov
+git+https://github.com/NVIDIA-Merlin/core.git
+git+https://github.com/NVIDIA-Merlin/NVTabular.git
+git+https://github.com/NVIDIA-Merlin/models.git

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-cudf>=21.12
-dask-cudf>=21.12
-dask-cuda>=21.12
-cupy>=7
+feast<=0.20.0
+faiss-gpu
+pytest
+pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,25 @@ deps =
     pytest
     pytest-cov
 commands =
-    python -m pytest --cov-report term --cov=merlin -rxs tests/unit/systems
+    python -m pytest --cov-report term --cov merlin -rxs tests/unit/systems
+
+[testenv:test-merlin]
+; This runs the end-to-end tests from the NVIDIA-Merlin/Merlin repo on the jenkins machine.
+; We will check out `Merlin` from github and execute the notebooks using the current PR of systems.
+passenv=GIT_COMMIT
+sitepackages=true
+allowlist_externals = git
+deps =
+    feast<=0.20.0
+    faiss-gpu
+    pytest
+    pytest-cov
+commands =
+    ; the GIT_COMMIT is the current commit of the systems repo
+    ; NOTE!!!! We must clean this up in the jenkins configuration with `rm -rf "Merlin-$GIT_COMMIT"`
+    git clone https://github.com/NVIDIA-Merlin/Merlin.git Merlin-{env:GIT_COMMIT}
+    ; this runs the tests then removes the Merlin repo directory whether the tests work or fail
+    python -m pytest --cov merlin --cov-report term Merlin-{env:GIT_COMMIT}/tests
 
 [testenv:lint]
 ; Runs in: Github Actions

--- a/tox.ini
+++ b/tox.ini
@@ -45,12 +45,11 @@ commands =
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/models.git
-    python -m pip freeze
 
     git clone https://github.com/NVIDIA-Merlin/Merlin.git Merlin-{env:GIT_COMMIT}
     python -m pip install .
     ; this runs the tests then removes the Merlin repo directory whether the tests work or fail
-    python -m pytest --cov merlin --cov-report term Merlin-{env:GIT_COMMIT}/tests/
+    python -m pytest --cov merlin --cov-report term Merlin-{env:GIT_COMMIT}/tests/unit
 
 [testenv:lint]
 ; Runs in: Github Actions

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ commands =
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/models.git
     python -m pip install dask==2022.3.0
+    python -m pip install distributed==2022.3.0
     python -m pip freeze
 
     git clone https://github.com/NVIDIA-Merlin/Merlin.git Merlin-{env:GIT_COMMIT}

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ commands =
     python -m pytest --cov-report term --cov merlin -rxs tests/unit/systems
 
 [testenv:test-merlin]
+; Runs in: Internal Jenkins
 ; This runs the end-to-end tests from the NVIDIA-Merlin/Merlin repo on the jenkins machine.
 ; We will check out `Merlin` from github and execute the notebooks using the current PR of systems.
 passenv=GIT_COMMIT
@@ -47,7 +48,7 @@ commands =
     git clone https://github.com/NVIDIA-Merlin/Merlin.git Merlin-{env:GIT_COMMIT}
     python -m pip install .
     ; this runs the tests then removes the Merlin repo directory whether the tests work or fail
-    python -m pytest --cov merlin --cov-report term Merlin-{env:GIT_COMMIT}/tests/unit
+    python -m pytest --cov merlin --cov-report term Merlin-{env:GIT_COMMIT}/tests/integration
 
 [testenv:lint]
 ; Runs in: Github Actions

--- a/tox.ini
+++ b/tox.ini
@@ -38,17 +38,15 @@ passenv=GIT_COMMIT
 sitepackages=true
 allowlist_externals = git
 deps =
-    feast<=0.20.0
-    faiss-gpu
-    pytest
-    pytest-cov
+    -rrequirements-gpu.txt
 commands =
     ; the GIT_COMMIT is the current commit of the systems repo
     ; NOTE!!!! We must clean this up in the jenkins configuration with `rm -rf "Merlin-$GIT_COMMIT"`
+    pip freeze
     git clone https://github.com/NVIDIA-Merlin/Merlin.git Merlin-{env:GIT_COMMIT}
     python -m pip install .
     ; this runs the tests then removes the Merlin repo directory whether the tests work or fail
-    python -m pytest --cov merlin --cov-report term Merlin-{env:GIT_COMMIT}/tests/integration
+    python -m pytest --cov merlin --cov-report term Merlin-{env:GIT_COMMIT}/tests/unit
 
 [testenv:lint]
 ; Runs in: Github Actions

--- a/tox.ini
+++ b/tox.ini
@@ -42,10 +42,11 @@ deps =
 commands =
     ; the GIT_COMMIT is the current commit of the systems repo
     ; NOTE!!!! We must clean this up in the jenkins configuration with `rm -rf "Merlin-$GIT_COMMIT"`
-    python -m pip freeze
+    
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/models.git
+    python -m pip freeze
 
     git clone https://github.com/NVIDIA-Merlin/Merlin.git Merlin-{env:GIT_COMMIT}
     python -m pip install .

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,11 @@ deps =
 commands =
     ; the GIT_COMMIT is the current commit of the systems repo
     ; NOTE!!!! We must clean this up in the jenkins configuration with `rm -rf "Merlin-$GIT_COMMIT"`
-    pip freeze
+    python -m pip freeze
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/models.git
+
     git clone https://github.com/NVIDIA-Merlin/Merlin.git Merlin-{env:GIT_COMMIT}
     python -m pip install .
     ; this runs the tests then removes the Merlin repo directory whether the tests work or fail

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ commands =
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/models.git
+    python -m pip install dask==2022.3.0
     python -m pip freeze
 
     git clone https://github.com/NVIDIA-Merlin/Merlin.git Merlin-{env:GIT_COMMIT}

--- a/tox.ini
+++ b/tox.ini
@@ -45,8 +45,9 @@ commands =
     ; the GIT_COMMIT is the current commit of the systems repo
     ; NOTE!!!! We must clean this up in the jenkins configuration with `rm -rf "Merlin-$GIT_COMMIT"`
     git clone https://github.com/NVIDIA-Merlin/Merlin.git Merlin-{env:GIT_COMMIT}
+    python -m pip install .
     ; this runs the tests then removes the Merlin repo directory whether the tests work or fail
-    python -m pytest --cov merlin --cov-report term Merlin-{env:GIT_COMMIT}/tests
+    python -m pytest --cov merlin --cov-report term Merlin-{env:GIT_COMMIT}/tests/unit
 
 [testenv:lint]
 ; Runs in: Github Actions

--- a/tox.ini
+++ b/tox.ini
@@ -40,20 +40,17 @@ allowlist_externals = git
 deps =
     -rrequirements-gpu.txt
 commands =
-    ; the GIT_COMMIT is the current commit of the systems repo
+    ; the GIT_COMMIT env is the current commit of the systems repo
     ; NOTE!!!! We must clean this up in the jenkins configuration with `rm -rf "Merlin-$GIT_COMMIT"`
-    
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/models.git
-    python -m pip install dask==2022.3.0
-    python -m pip install distributed==2022.3.0
     python -m pip freeze
 
     git clone https://github.com/NVIDIA-Merlin/Merlin.git Merlin-{env:GIT_COMMIT}
     python -m pip install .
     ; this runs the tests then removes the Merlin repo directory whether the tests work or fail
-    python -m pytest --cov merlin --cov-report term Merlin-{env:GIT_COMMIT}/tests/unit
+    python -m pytest --cov merlin --cov-report term Merlin-{env:GIT_COMMIT}/tests/
 
 [testenv:lint]
 ; Runs in: Github Actions


### PR DESCRIPTION
This will

* Clone the NVIDIA-Merlin/Merlin repo to the directory `Merlin-$COMMIT_SHA` for this branch's commit sha.
* Run `pip install .` for this branch of systems (necessary??)
* Run the Merlin repo tests

Right now now, I expect the cloned repo to be cleaned up by Jenkins. Tox doesn't really have a "cleanup" phase, unfortunately.

I am also manually updating `dask` and `distributed` to  >=2022.3.0. For some reason, our jenkins image is somehow downgrading the version which causes an error when running the Merlin notebook tests. Work is in progress to sort that out, but we are able to unblock this PR by upgrading it here.

Update:

* There is a flakiness issue with the Merlin integration tests, so I downgraded this to only run unit tests for now.
* I'd like to split this into its own build check so that it can run on jenkins in parallel with the systems repo tests. TBD.