### PR TITLE
Specify `is_ragged=False` explicitly in the Feast tests

### DIFF
--- a/tests/unit/systems/ops/feast/test_op.py
+++ b/tests/unit/systems/ops/feast/test_op.py
@@ -111,7 +111,10 @@ def test_feast_from_feature_view(tmpdir, suffix_int):
                     is_ragged=True,
                 ),
                 ColumnSchema(
-                    name=f"prefix_int_list_feature_{suffix_int+1}", dtype=np.int32, is_list=True
+                    name=f"prefix_int_list_feature_{suffix_int+1}",
+                    dtype=np.int32,
+                    is_list=True,
+                    is_ragged=False,
                 ),
                 ColumnSchema(
                     name=f"prefix_float_list_feature_{suffix_int}",
@@ -123,6 +126,7 @@ def test_feast_from_feature_view(tmpdir, suffix_int):
                     name=f"prefix_float_list_feature_{suffix_int+1}",
                     dtype=np.int32,
                     is_list=True,
+                    is_ragged=False,
                 ),
                 ColumnSchema(name="item_id", dtype=np.int32),
             ]


### PR DESCRIPTION
The second array representing a ragged column should have `is_ragged=False` since the number of items is fixed.