### PR TITLE
Mark example notebook tests to make them skippable in other repos

### DIFF
--- a/ci/test_unit.sh
+++ b/ci/test_unit.sh
@@ -18,5 +18,6 @@
 set -e
 
 # Run tests
-pytest -rsx tests/unit
+pytest -rsx tests/unit tests/notebook
+
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    notebook: mark a test as testing notebooks

--- a/tests/unit/examples/test_serving_an_xgboost_model_with_merlin_systems.py
+++ b/tests/unit/examples/test_serving_an_xgboost_model_with_merlin_systems.py
@@ -9,6 +9,7 @@ pytest.importorskip("merlin.models")
 pytest.importorskip("xgboost")
 
 
+@pytest.mark.notebook
 @testbook(REPO_ROOT / "examples/Serving-An-XGboost-Model-With-Merlin-Systems.ipynb", execute=False)
 def test_example_serving_xgboost(tb):
     tb.inject(

--- a/tests/unit/examples/test_serving_ranking_models_with_merlin_systems.py
+++ b/tests/unit/examples/test_serving_ranking_models_with_merlin_systems.py
@@ -10,6 +10,7 @@ pytest.importorskip("tensorflow")
 pytest.importorskip("merlin.models")
 
 
+@pytest.mark.notebook
 @testbook(REPO_ROOT / "examples/Serving-Ranking-Models-With-Merlin-Systems.ipynb", execute=False)
 def test_example_04_exporting_ranking_models(tb):
     import tensorflow as tf


### PR DESCRIPTION
Marking the notebook tests allows them to be skipped with `pytest -m "not notebook"`