### PR TITLE
Add extra requirements files to `setup.py` as optional installs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include versioneer.py
 recursive-include merlin *.py *.proto
 include requirements.txt
-include requirements-dev.txt
+include requirements-*.txt
 
 include merlin/core/_version.py

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,7 +9,7 @@
 pytest>=5
 pytest-cov>=2
 scikit-learn>=0.20
-git+https://github.com/rapidsai/asvdb.git
+asvdb@git+https://github.com/rapidsai/asvdb.git
 testbook==0.4.2
 
 # packages necessary to run tests and push PRs

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import codecs
 import os
 import sys
 
@@ -29,13 +30,48 @@ except ImportError:
     import versioneer
 
 
+def read_requirements(filename):
+    base = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(base, filename), "rb", "utf-8") as f:
+        lineiter = (line.strip() for line in f)
+        packages = []
+        for line in lineiter:
+            if line:
+                if line.startswith("-r"):
+                    filename = line.replace("-r", "").strip()
+                    packages.extend(read_requirements(filename))
+                elif not line.startswith("#"):
+                    packages.append(line)
+        return packages
+
+
 def parse_requirements(filename):
     """load requirements from a pip requirements file"""
-    lineiter = (line.strip() for line in open(filename))
-    return [line for line in lineiter if line and not line.startswith("#")]
+    with open(filename, encoding="utf-8") as req_file:
+        lineiter = (line.strip() for line in req_file)
+        packages = []
+        for line in lineiter:
+            if line.startswith("-r"):
+                packages.extend(parse_requirements)
+            if not line.startswith("#"):
+                packages.append(line)
+        return packages
 
 
-install_reqs = parse_requirements("./requirements.txt")
+requirements = {
+    "cpu": read_requirements("./requirements.txt"),
+    "gpu": read_requirements("./requirements-gpu.txt"),
+}
+dev_requirements = {
+    "dev": read_requirements("./requirements-dev.txt"),
+    "test": read_requirements("./requirements-test.txt"),
+    "test-cpu": read_requirements("./requirements-test-cpu.txt"),
+    "test-gpu": read_requirements("./requirements-test-gpu.txt"),
+    "docs": read_requirements("./requirements-docs.txt"),
+}
+
+with open("README.md", encoding="utf8") as readme_file:
+    long_description = readme_file.read()
 
 setup(
     name="merlin-systems",
@@ -44,7 +80,7 @@ setup(
     url="https://github.com/NVIDIA-Merlin/systems",
     author="NVIDIA Corporation",
     license="Apache 2.0",
-    long_description=open("README.md", encoding="utf8").read(),
+    long_description=long_description,
     long_description_content_type="text/markdown",
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -55,6 +91,10 @@ setup(
         "Topic :: Scientific/Engineering",
     ],
     zip_safe=False,
-    install_requires=install_reqs,
+    install_requires=requirements["cpu"],
+    extras_require={
+        **requirements,
+        **dev_requirements,
+    },
     cmdclass=versioneer.get_cmdclass(),
 )

--- a/setup.py
+++ b/setup.py
@@ -45,29 +45,16 @@ def read_requirements(filename):
         return packages
 
 
-def parse_requirements(filename):
-    """load requirements from a pip requirements file"""
-    with open(filename, encoding="utf-8") as req_file:
-        lineiter = (line.strip() for line in req_file)
-        packages = []
-        for line in lineiter:
-            if line.startswith("-r"):
-                packages.extend(parse_requirements)
-            if not line.startswith("#"):
-                packages.append(line)
-        return packages
-
-
 requirements = {
-    "cpu": read_requirements("./requirements.txt"),
-    "gpu": read_requirements("./requirements-gpu.txt"),
+    "cpu": read_requirements("requirements.txt"),
+    "gpu": read_requirements("requirements-gpu.txt"),
 }
 dev_requirements = {
-    "dev": read_requirements("./requirements-dev.txt"),
-    "test": read_requirements("./requirements-test.txt"),
-    "test-cpu": read_requirements("./requirements-test-cpu.txt"),
-    "test-gpu": read_requirements("./requirements-test-gpu.txt"),
-    "docs": read_requirements("./requirements-docs.txt"),
+    "dev": read_requirements("requirements-dev.txt"),
+    "test": read_requirements("requirements-test.txt"),
+    "test-cpu": read_requirements("requirements-test-cpu.txt"),
+    "test-gpu": read_requirements("requirements-test-gpu.txt"),
+    "docs": read_requirements("requirements-docs.txt"),
 }
 
 with open("README.md", encoding="utf8") as readme_file:


### PR DESCRIPTION
Hoping this will make it a bit easier to install downstream libraries and their test requirements from the `tox` envs for `core`.