### PR TITLE
Remove `importorskip("tritonclient")` from the tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,10 +50,6 @@ except ImportError:
 
 
 REPO_ROOT = Path(__file__).parent.parent
-
-grpcclient = pytest.importorskip("tritonclient.grpc")
-tritonclient = pytest.importorskip("tritonclient")
-
 TRITON_SERVER_PATH = find_executable("tritonserver")
 
 

--- a/tests/unit/systems/dag/test_model_registry.py
+++ b/tests/unit/systems/dag/test_model_registry.py
@@ -26,7 +26,6 @@ from merlin.systems.dag.ops.operator import InferenceOperator  # noqa
 from merlin.systems.model_registry import MLFlowModelRegistry, ModelRegistry  # noqa
 
 ensemble = pytest.importorskip("merlin.systems.dag.ensemble")
-model_config = pytest.importorskip("tritonclient.grpc.model_config_pb2")
 workflow_op = pytest.importorskip("merlin.systems.dag.ops.workflow")
 
 

--- a/tests/unit/systems/ops/fil/test_ensemble.py
+++ b/tests/unit/systems/ops/fil/test_ensemble.py
@@ -38,9 +38,6 @@ from merlin.systems.dag.ensemble import Ensemble  # noqa
 from merlin.systems.dag.ops.workflow import TransformWorkflow  # noqa
 from tests.unit.systems.utils.triton import _run_ensemble_on_tritonserver  # noqa
 
-tritonclient = pytest.importorskip("tritonclient")
-grpcclient = pytest.importorskip("tritonclient.grpc")
-
 TRITON_SERVER_PATH = find_executable("tritonserver")
 
 

--- a/tests/unit/systems/ops/fil/test_forest.py
+++ b/tests/unit/systems/ops/fil/test_forest.py
@@ -21,6 +21,7 @@ import pytest
 import sklearn.datasets
 import xgboost
 from google.protobuf import text_format
+from tritonclient.grpc import model_config_pb2 as model_config
 
 from merlin.core.utils import Distributed
 from merlin.dag import ColumnSelector
@@ -31,9 +32,6 @@ from merlin.systems.dag.ops.fil import PredictForest
 from merlin.systems.dag.ops.workflow import TransformWorkflow
 from nvtabular import Workflow
 from nvtabular import ops as wf_ops
-
-tritonclient = pytest.importorskip("tritonclient")
-import tritonclient.grpc.model_config_pb2 as model_config  # noqa
 
 
 def test_load_from_config(tmpdir):

--- a/tests/unit/systems/ops/fil/test_op.py
+++ b/tests/unit/systems/ops/fil/test_op.py
@@ -31,8 +31,7 @@ from merlin.schema import Schema
 os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
 from google.protobuf import text_format  # noqa
-
-model_config = pytest.importorskip("tritonclient.grpc.model_config_pb2")
+from tritonclient.grpc import model_config_pb2 as model_config  # noqa
 
 
 def export_op(export_dir, triton_op) -> model_config.ModelConfig:

--- a/tests/unit/systems/ops/implicit/test_op.py
+++ b/tests/unit/systems/ops/implicit/test_op.py
@@ -20,6 +20,7 @@ import implicit
 import numpy as np
 import pytest
 from scipy.sparse import csr_matrix
+from tritonclient import grpc as grpcclient
 
 from merlin.schema import ColumnSchema, Schema
 from merlin.systems.dag.ensemble import Ensemble
@@ -29,7 +30,6 @@ from merlin.systems.triton.utils import run_triton_server
 TRITON_SERVER_PATH = find_executable("tritonserver")
 
 triton = pytest.importorskip("merlin.systems.triton")
-grpcclient = pytest.importorskip("tritonclient.grpc")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/systems/ops/nvtabular/test_op.py
+++ b/tests/unit/systems/ops/nvtabular/test_op.py
@@ -22,13 +22,13 @@ import pytest
 os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
 from google.protobuf import text_format  # noqa
+from tritonclient.grpc import model_config_pb2 as model_config  # noqa
 
 from merlin.schema import Schema  # noqa
 from nvtabular import Workflow  # noqa
 from nvtabular import ops as wf_ops  # noqa
 
 ensemble = pytest.importorskip("merlin.systems.dag.ensemble")
-model_config = pytest.importorskip("tritonclient.grpc.model_config_pb2")
 workflow_op = pytest.importorskip("merlin.systems.dag.ops.workflow")
 
 

--- a/tests/unit/systems/ops/tf/test_ensemble.py
+++ b/tests/unit/systems/ops/tf/test_ensemble.py
@@ -37,16 +37,13 @@ tf = pytest.importorskip("tensorflow")
 triton = pytest.importorskip("merlin.systems.triton")
 export = pytest.importorskip("merlin.systems.dag.ensemble")
 
+import tritonclient.grpc.model_config_pb2 as model_config  # noqa
+
 from merlin.systems.dag.ensemble import Ensemble  # noqa
 from merlin.systems.dag.ops.tensorflow import PredictTensorflow  # noqa
 from merlin.systems.dag.ops.workflow import TransformWorkflow  # noqa
 from tests.unit.systems.utils.tf import create_tf_model  # noqa
 from tests.unit.systems.utils.triton import _run_ensemble_on_tritonserver  # noqa
-
-tritonclient = pytest.importorskip("tritonclient")
-import tritonclient.grpc.model_config_pb2 as model_config  # noqa
-
-grpcclient = pytest.importorskip("tritonclient.grpc")
 
 TRITON_SERVER_PATH = find_executable("tritonserver")
 

--- a/tests/unit/systems/ops/tf/test_op.py
+++ b/tests/unit/systems/ops/tf/test_op.py
@@ -28,8 +28,8 @@ from merlin.schema import ColumnSchema, Schema
 os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
 from google.protobuf import text_format  # noqa
+from tritonclient.grpc import model_config_pb2 as model_config  # noqa
 
-model_config = pytest.importorskip("tritonclient.grpc.model_config_pb2")
 tf_op = pytest.importorskip("merlin.systems.dag.ops.tensorflow")
 
 tf = pytest.importorskip("tensorflow")

--- a/tests/unit/systems/ops/torch/test_op.py
+++ b/tests/unit/systems/ops/torch/test_op.py
@@ -22,6 +22,8 @@ from typing import Dict
 import numpy as np
 import pytest
 from google.protobuf import text_format
+from tritonclient import grpc as grpcclient
+from tritonclient.grpc import model_config_pb2
 
 from merlin.schema import ColumnSchema, Schema
 from merlin.systems.dag.ensemble import Ensemble
@@ -31,9 +33,7 @@ TRITON_SERVER_PATH = find_executable("tritonserver")
 
 torch = pytest.importorskip("torch")
 triton = pytest.importorskip("merlin.systems.triton")
-grpcclient = pytest.importorskip("tritonclient.grpc")
 ptorch_op = pytest.importorskip("merlin.systems.dag.ops.pytorch")
-model_config_pb2 = pytest.importorskip("tritonclient.grpc.model_config_pb2")
 
 
 class CustomModel(torch.nn.Module):

--- a/tests/unit/systems/test_export.py
+++ b/tests/unit/systems/test_export.py
@@ -30,13 +30,11 @@ ensemble = pytest.importorskip("merlin.systems.triton.export")
 
 torch = pytest.importorskip("torch")  # noqa
 
+
 from merlin.systems.triton.export import export_pytorch_ensemble, export_tensorflow_ensemble  # noqa
 from tests.unit.systems.utils.tf import create_tf_model  # noqa
 from tests.unit.systems.utils.torch import create_pytorch_model  # noqa
 from tests.unit.systems.utils.triton import _run_ensemble_on_tritonserver  # noqa
-
-tritonclient = pytest.importorskip("tritonclient")
-grpcclient = pytest.importorskip("tritonclient.grpc")
 
 TRITON_SERVER_PATH = find_executable("tritonserver")
 tf_utils.configure_tensorflow()

--- a/tests/unit/systems/utils/triton.py
+++ b/tests/unit/systems/utils/triton.py
@@ -16,12 +16,10 @@
 from distutils.spawn import find_executable
 
 import pytest
+from tritonclient import grpc as grpcclient
 
 triton = pytest.importorskip("merlin.systems.triton")
 data_conversions = pytest.importorskip("merlin.systems.triton.conversions")
-
-tritonclient = pytest.importorskip("tritonclient")
-grpcclient = pytest.importorskip("tritonclient.grpc")
 
 TRITON_SERVER_PATH = find_executable("tritonserver")
 from merlin.systems.triton.utils import run_triton_server  # noqa


### PR DESCRIPTION
Now that `tritonclient` is a test dependency, we don't have to keep checking if it's available everywhere.