### PR TITLE
Skip "serving ranking models" example test on CPU

### DIFF
--- a/tests/unit/examples/test_serving_ranking_models_with_merlin_systems.py
+++ b/tests/unit/examples/test_serving_ranking_models_with_merlin_systems.py
@@ -5,6 +5,7 @@ from testbook import testbook
 
 from tests.conftest import REPO_ROOT
 
+pytest.importorskip("cudf")
 pytest.importorskip("tensorflow")
 pytest.importorskip("merlin.models")
 


### PR DESCRIPTION
This test fails in environments that have GPUs but are running CPU tests in an environment without `cudf`