### PR TITLE
Add properties for input and output schemas to `Ensemble`

### DIFF
--- a/merlin/systems/dag/ensemble.py
+++ b/merlin/systems/dag/ensemble.py
@@ -52,6 +52,14 @@ class Ensemble:
         self.name = name
         self.label_columns = label_columns or []
 
+    @property
+    def input_schema(self):
+        return self.graph.input_schema
+
+    @property
+    def output_schema(self):
+        return self.graph.output_schema
+
     def export(self, export_path, version=1):
         """
         Write out an ensemble model configuration directory. The exported
@@ -128,7 +136,8 @@ class Ensemble:
         os.makedirs(ensemble_path, exist_ok=True)
         os.makedirs(os.path.join(ensemble_path, str(version)), exist_ok=True)
 
-        with open(os.path.join(ensemble_path, "config.pbtxt"), "w") as o:
+        config_path = os.path.join(ensemble_path, "config.pbtxt")
+        with open(config_path, "w", encoding="utf-8") as o:
             text_format.PrintMessage(ensemble_config, o)
 
         return (ensemble_config, node_configs)

--- a/tests/unit/systems/dag/ops/test_ops.py
+++ b/tests/unit/systems/dag/ops/test_ops.py
@@ -50,7 +50,7 @@ def test_softmax_sampling(tmpdir):
     ens_config, node_configs = ensemble.export(tmpdir)
 
     response = _run_ensemble_on_tritonserver(
-        tmpdir, ensemble.graph.output_schema.column_names, request, "ensemble_model"
+        tmpdir, ensemble.output_schema.column_names, request, "ensemble_model"
     )
     assert response is not None
     assert len(response.as_numpy("ordered_ids")) == 10
@@ -82,7 +82,7 @@ def test_filter_candidates(tmpdir):
     ens_config, node_configs = ensemble.export(tmpdir)
 
     response = _run_ensemble_on_tritonserver(
-        tmpdir, ensemble.graph.output_schema.column_names, request, "ensemble_model"
+        tmpdir, ensemble.output_schema.column_names, request, "ensemble_model"
     )
     assert response is not None
     assert len(response.as_numpy("filtered_ids")) == 80

--- a/tests/unit/systems/dag/test_graph.py
+++ b/tests/unit/systems/dag/test_graph.py
@@ -38,13 +38,15 @@ def test_inference_schema_propagation():
     workflow = Workflow(workflow_ops)
     workflow.fit_schema(request_schema)
 
-    assert workflow.graph.output_schema == expected_schema
+    assert workflow.input_schema == request_schema
+    assert workflow.output_schema == expected_schema
 
     # Triton
     triton_ops = input_columns >> workflow_op.TransformWorkflow(workflow)
     ensemble_out = ensemble.Ensemble(triton_ops, request_schema)
 
-    assert ensemble_out.graph.output_schema == expected_schema
+    assert ensemble_out.input_schema == request_schema
+    assert ensemble_out.output_schema == expected_schema
 
 
 def test_graph_traverse_algo():

--- a/tests/unit/systems/ops/tf/test_ensemble.py
+++ b/tests/unit/systems/ops/tf/test_ensemble.py
@@ -102,7 +102,7 @@ def test_workflow_tf_e2e_config_verification(tmpdir, dataset, engine):
 
     df = make_df({"x": [1.0, 2.0, 3.0], "y": [4.0, 5.0, 6.0], "id": [7, 8, 9]})
 
-    output_columns = triton_ens.graph.output_schema.column_names
+    output_columns = triton_ens.output_schema.column_names
     response = _run_ensemble_on_tritonserver(str(tmpdir), output_columns, df, triton_ens.name)
     assert len(response.as_numpy("output")) == df.shape[0]
 


### PR DESCRIPTION
It's a little confusing to examine the input and output schemas of ensembles right now, since only the operators have `input_schema` and `output_schema` properties, but the ensemble's input schema is the "sum" of the input schemas of all the operators that immediately process the raw request and the ensemble's output schema is the output schema of the final operator/node. This PR adds methods that allow you to introspect the ensemble's input and output schemas (for use in examples or troubleshooting.)