### PR TITLE
Fix versioneer to get accurate version numbers

### DIFF
--- a/merlin/systems/_version.py
+++ b/merlin/systems/_version.py
@@ -42,7 +42,7 @@ def get_config():
     cfg = VersioneerConfig()
     cfg.VCS = "git"
     cfg.style = "pep440"
-    cfg.tag_prefix = ""
+    cfg.tag_prefix = "v"
     cfg.parentdir_prefix = "merlin-systems-"
     cfg.versionfile_source = "merlin/systems/_version.py"
     cfg.verbose = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,5 +28,5 @@ VCS = git
 style = pep440
 versionfile_source = merlin/systems/_version.py
 versionfile_build = merlin/systems/_version.py
-tag_prefix =
+tag_prefix = v
 parentdir_prefix = merlin-systems-

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from packaging.version import Version
 
 import merlin.systems
 
 
 def test_version():
     """test to get back version of library"""
-    assert merlin.systems.__version__ is not None
+    assert Version(merlin.systems.__version__) >= Version("0.5.0")


### PR DESCRIPTION
The update to versioneer in #114 resulted in us not getting versions from git. This is because we weren't specifying the tag_prefix appropriately, and this broke newer versions of versioneer.

Fix and add a basic unittest that would catch issues like this in the future