### PR TITLE
run example tests in pr

### DIFF
--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/tests/unit/examples/test_serving_an_xgboost_model_with_merlin_systems.py
+++ b/tests/unit/examples/test_serving_an_xgboost_model_with_merlin_systems.py
@@ -1,4 +1,5 @@
 from distutils.spawn import find_executable  # pylint: disable=deprecated-module
+
 import pytest
 from testbook import testbook
 

--- a/tests/unit/examples/test_serving_an_xgboost_model_with_merlin_systems.py
+++ b/tests/unit/examples/test_serving_an_xgboost_model_with_merlin_systems.py
@@ -1,3 +1,4 @@
+from distutils.spawn import find_executable  # pylint: disable=deprecated-module
 import pytest
 from testbook import testbook
 
@@ -8,7 +9,10 @@ pytest.importorskip("tensorflow")
 pytest.importorskip("merlin.models")
 pytest.importorskip("xgboost")
 
+TRITON_SERVER_PATH = find_executable("tritonserver")
 
+
+@pytest.mark.skipif(not TRITON_SERVER_PATH, reason="triton server not found")
 @pytest.mark.notebook
 @testbook(REPO_ROOT / "examples/Serving-An-XGboost-Model-With-Merlin-Systems.ipynb", execute=False)
 def test_example_serving_xgboost(tb):

--- a/tox.ini
+++ b/tox.ini
@@ -14,10 +14,7 @@ commands =
 ; Runs all CPU-based tests. NOTE: if you are using an M1 mac, this will fail. You need to
 ; change the tensorflow dependency to `tensorflow-macos` in requirements/test-cpu.txt.
 deps = -rrequirements/test-cpu.txt
-allowlist_externals = git
-commands =
-    git tag --list
-    python -m pytest --cov-report term --cov=merlin -rxs tests/unit
+commands = python -m pytest --cov-report term --cov=merlin -rxs tests/unit
 
 [testenv:test-gpu]
 sitepackages=true

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,10 @@ commands =
 ; Runs all CPU-based tests. NOTE: if you are using an M1 mac, this will fail. You need to
 ; change the tensorflow dependency to `tensorflow-macos` in requirements/test-cpu.txt.
 deps = -rrequirements/test-cpu.txt
-commands = python -m pytest --cov-report term --cov=merlin -rxs tests/unit
+allowlist_externals = git
+commands =
+    git tag --list
+    python -m pytest --cov-report term --cov=merlin -rxs tests/unit
 
 [testenv:test-gpu]
 sitepackages=true

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands =
 ; Runs all CPU-based tests. NOTE: if you are using an M1 mac, this will fail. You need to
 ; change the tensorflow dependency to `tensorflow-macos` in requirements/test-cpu.txt.
 deps = -rrequirements/test-cpu.txt
-commands = python -m pytest --cov-report term --cov=merlin -rxs tests/unit/systems
+commands = python -m pytest --cov-report term --cov=merlin -rxs tests/unit
 
 [testenv:test-gpu]
 sitepackages=true
@@ -28,7 +28,7 @@ deps =
     pytest
     pytest-cov
 commands =
-    python -m pytest --cov-report term --cov merlin -rxs tests/unit/systems
+    python -m pytest --cov-report term --cov merlin -rxs tests/unit
 
 [testenv:test-merlin]
 ; Runs in: Internal Jenkins


### PR DESCRIPTION
We were only running the `tests/unit/systems` tests, and not including the notebook examples. This adds them back.