### PR TITLE
Mark the version test so it can be skipped in other repos

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     notebook: mark a test as testing notebooks
+    version: mark a test as testing the version number

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -13,11 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import pytest
 from packaging.version import Version
 
 import merlin.systems
 
 
+@pytest.mark.version
 def test_version():
     """test to get back version of library"""
     assert Version(merlin.systems.__version__) >= Version("0.5.0")


### PR DESCRIPTION
When we install from source in the CPU CI tests in other repos, the version numbers won't pass this test. Marking it so it can be skipped with `pytest -m not version`.