### PR TITLE
Upgrade Feast to 0.27

### DIFF
--- a/merlin/systems/dag/ops/feast.py
+++ b/merlin/systems/dag/ops/feast.py
@@ -1,8 +1,9 @@
 import json
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 from feast import FeatureStore, ValueType
+from feast.types import VALUE_TYPES_TO_FEAST_TYPES
 
 from merlin.core.protocols import Transformable
 from merlin.dag import ColumnSelector
@@ -10,7 +11,7 @@ from merlin.schema import ColumnSchema, Schema
 from merlin.systems.dag.ops.operator import PipelineableInferenceOperator
 
 # Feast_key: (numpy dtype, is_list, is_ragged)
-feast_2_numpy = {
+feast_2_numpy: Dict[ValueType, Tuple] = {
     ValueType.INT64: (np.int64, False, False),
     ValueType.INT32: (np.int32, False, False),
     ValueType.FLOAT: (np.float32, False, False),
@@ -18,6 +19,8 @@ feast_2_numpy = {
     ValueType.INT32_LIST: (np.int32, True, True),
     ValueType.FLOAT_LIST: (np.float32, True, True),
 }
+
+FEAST_TYPES_TO_VALUE_TYPES = {v: k for k, v in VALUE_TYPES_TO_FEAST_TYPES.items()}
 
 
 class QueryFeast(PipelineableInferenceOperator):
@@ -83,7 +86,9 @@ class QueryFeast(PipelineableInferenceOperator):
 
         output_schema = Schema([])
         for feature in feature_view.features:
-            feature_dtype, is_list, is_ragged = feast_2_numpy[feature.dtype]
+            feature_dtype, is_list, is_ragged = feast_2_numpy[
+                FEAST_TYPES_TO_VALUE_TYPES[feature.dtype]
+            ]
 
             if is_list:
                 mh_features.append(feature.name)

--- a/merlin/systems/dag/ops/feast.py
+++ b/merlin/systems/dag/ops/feast.py
@@ -20,6 +20,7 @@ feast_2_numpy: Dict[ValueType, Tuple] = {
     ValueType.FLOAT_LIST: (np.float32, True, True),
 }
 
+# We need an inverted-index of Feast's VALUE_TYPES_TO_FEAST_TYPES mapping.
 FEAST_TYPES_TO_VALUE_TYPES = {v: k for k, v in VALUE_TYPES_TO_FEAST_TYPES.items()}
 
 

--- a/merlin/systems/dag/ops/feast.py
+++ b/merlin/systems/dag/ops/feast.py
@@ -1,5 +1,5 @@
 import json
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 from feast import FeatureStore, ValueType
@@ -36,7 +36,7 @@ class QueryFeast(PipelineableInferenceOperator):
         store: FeatureStore,
         view: str,
         column: str,
-        output_prefix: str = None,
+        output_prefix: Optional[str] = None,
         include_id: bool = False,
     ):
         """
@@ -52,7 +52,7 @@ class QueryFeast(PipelineableInferenceOperator):
             The feature view you want to pull feature from.
         column : str
             The column that input data will match against.
-        output_prefix : str, optional
+        output_prefix : Optional[str], optional
             A column prefix that can be added to each output column, by default None
         include_id : bool, optional
             A boolean to decide to include the input column in output, by default False

--- a/requirements/gpu.txt
+++ b/requirements/gpu.txt
@@ -1,4 +1,4 @@
-feast~=0.25
+feast~=0.25.0
 faiss-gpu
 pytest
 pytest-cov

--- a/requirements/gpu.txt
+++ b/requirements/gpu.txt
@@ -1,4 +1,4 @@
-feast<0.20
+feast~=0.25
 faiss-gpu
 pytest
 pytest-cov

--- a/requirements/gpu.txt
+++ b/requirements/gpu.txt
@@ -1,4 +1,4 @@
-feast~=0.25.0
+feast~=0.27.0
 faiss-gpu
 pytest
 pytest-cov

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,7 @@ testbook==0.4.2
 
 # packages necessary to run tests and push PRs
 tritonclient
-feast~=0.27.0
+# feast~=0.27.0
 xgboost==1.6.2
 implicit==0.6.0
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,7 @@ testbook==0.4.2
 
 # packages necessary to run tests and push PRs
 tritonclient
-feast==0.19.4
+feast~=0.27.0
 xgboost==1.6.2
 implicit==0.6.0
 

--- a/tests/unit/systems/ops/feast/test_op.py
+++ b/tests/unit/systems/ops/feast/test_op.py
@@ -12,10 +12,10 @@ from merlin.systems.dag import DictArray
 feast = pytest.importorskip("feast")  # noqa
 
 from feast import Entity, Field  # noqa
-from feast.types import Int32, Float32, Array  # noqa
 from feast.online_response import OnlineResponse  # noqa
 from feast.protos.feast.serving import ServingService_pb2  # noqa
 from feast.protos.feast.types import Value_pb2  # noqa
+from feast.types import Array, Float32, Int32  # noqa
 from feast.value_type import ValueType  # noqa
 
 from merlin.systems.dag.ops.feast import QueryFeast  # noqa

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
 deps = -rrequirements/test-cpu.txt
 commands =
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
-    python -m pip install feast~0.27
+    python -m pip install feast~=0.27
     python -m pip install .
     
     python -m pytest --cov-report term --cov=merlin -rxs tests/unit

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ commands =
 deps = -rrequirements/test-cpu.txt
 commands =
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
+    python -m pip install feast~0.27
     python -m pip install .
     
     python -m pytest --cov-report term --cov=merlin -rxs tests/unit


### PR DESCRIPTION
Upgrades Feast to the current version, 0.27. This _should_ be complete but we need to verify the following:

- [ ] Update pinned Feast version in all of our containers (better: remove them and handle it via tox)
- [ ] Update the Merlin example notebooks to work (in progress)
