### PR TITLE
Adjust `Node.exportable()` to catch up to Merlin Core

### DIFF
--- a/merlin/systems/dag/ops/operator.py
+++ b/merlin/systems/dag/ops/operator.py
@@ -71,6 +71,10 @@ class InferenceOperator(BaseOperator):
         """
         return self.__class__.__name__.lower()
 
+    @property
+    def exportable_backends(self):
+        return ["ensemble"]
+
     @abstractmethod
     def export(
         self,


### PR DESCRIPTION
As we prepare to export and/or run Merlin graphs in multiple contexts, the signature of `Node.exportable()` has changed a little. Further related changes are coming in #204, but these small changes make the tests pass with the latest `main` version of Core.