### PR TITLE
Create a separate directory parallel to `unit` for version tests

### DIFF
--- a/tests/version/test_version.py
+++ b/tests/version/test_version.py
@@ -22,4 +22,4 @@ import merlin.systems
 @pytest.mark.version
 def test_version():
     """test to get back version of library"""
-    assert Version(merlin.systems.__version__) >= Version("0.5.0")
+    assert Version(merlin.systems.__version__) >= Version("0.6.0")


### PR DESCRIPTION
This test fails all the time in development and other repos, since dev versions aren't `>=0.6.0`.