### PR TITLE
Add `requests` dependency to base requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,3 @@
 merlin-core>=0.2.0
 nvtabular>=1.0.0
+requests>=2.10,<3


### PR DESCRIPTION
Use of the `requests` library was added in #149 

Adding this library to `requirements/base.txt` to enable this dependency to be installed automatically if not already present.