### PR TITLE
fix for faiss artifact path from config

### DIFF
--- a/merlin/systems/dag/ops/faiss.py
+++ b/merlin/systems/dag/ops/faiss.py
@@ -63,7 +63,10 @@ class QueryFaiss(PipelineableInferenceOperator):
 
     def load_artifacts(self, artifact_path):
         filename = Path(self.index_path).name
-        full_index_path = str(Path(artifact_path) / filename)
+        path_artifact = Path(artifact_path)
+        if path_artifact.is_file():
+            path_artifact = path_artifact.parent
+        full_index_path = str(path_artifact / filename)
         index = faiss.read_index(full_index_path)
 
         if HAS_GPU:


### PR DESCRIPTION
When we run the faiss operator as part of a triton ensemble, the operator will receive an index path that already has the index file name in it. We need to check if the artifact_path supplied is a file path or a directory path. If it is a file path we need to remove the file portion otherwise, use the entire artifact path supplied. This is an issue coming up in the merlin unit tests (https://github.com/NVIDIA-Merlin/Merlin/pull/705#issuecomment-1287173878). 