### PR TITLE
add env variable to handle gpu memory allocation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,8 @@ sitepackages=true
 ; and other gpu-specific libraries that we can enxpect will always exist. Thus, we don't need
 ; to install requirements.txt yet. As we get better at python environment isolation, we will
 ; need to add some back.
+setenv = 
+    TF_GPU_ALLOCATOR=cuda_malloc_async
 deps =
     pytest
     pytest-cov


### PR DESCRIPTION
This PR adds the environment variable `TF_GPU_ALLOCATOR=cuda_malloc_async` which solves issues with allocated gpu memory not being released after each test, causing issues in other PRs (i.e. https://github.com/NVIDIA-Merlin/systems/pull/219). 

