### PR TITLE
Update random sampling in tests to impove test reliability

### DIFF
--- a/tests/unit/systems/dag/ops/test_ops.py
+++ b/tests/unit/systems/dag/ops/test_ops.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import random
 from distutils.spawn import find_executable
 
 import numpy as np
@@ -38,7 +39,7 @@ def test_softmax_sampling(tmpdir):
     )
 
     combined_features = {
-        "movie_ids": np.random.randint(0, 10000, 100).astype(np.int32),
+        "movie_ids": np.array(random.sample(range(10000), 100), dtype=np.int32),
         "output_1": np.random.random(100).astype(np.float32),
     }
 
@@ -65,7 +66,7 @@ def test_filter_candidates_with_triton(tmpdir):
         ]
     )
 
-    candidate_ids = np.random.randint(1, 100000, 100).astype(np.int32)
+    candidate_ids = np.array(random.sample(range(100000), 100), dtype=np.int32)
     movie_ids_1 = np.zeros(100, dtype=np.int32)
     movie_ids_1[:20] = np.unique(candidate_ids)[:20]
 

--- a/tests/unit/systems/dag/test_ensemble.py
+++ b/tests/unit/systems/dag/test_ensemble.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import random
+
 import numpy as np
 
 from merlin.dag.executors import LocalExecutor
@@ -30,7 +32,7 @@ def test_ensemble_save_load(tmpdir):
         ]
     )
 
-    candidate_ids = np.random.randint(1, 100000, 100).astype(np.int32)
+    candidate_ids = np.array(random.sample(range(100000), 100), dtype=np.int32)
     movie_ids_1 = np.zeros(100, dtype=np.int32)
     movie_ids_1[:20] = np.unique(candidate_ids)[:20]
 

--- a/tests/unit/systems/dag/test_executors.py
+++ b/tests/unit/systems/dag/test_executors.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import random
 from distutils.spawn import find_executable
 
 import numpy as np
@@ -38,7 +39,7 @@ def test_run_dag_on_dictarray_with_local_executor():
         ]
     )
 
-    candidate_ids = np.random.randint(1, 100000, 100).astype(np.int32)
+    candidate_ids = np.array(random.sample(range(100000), 100), dtype=np.int32)
     movie_ids_1 = np.zeros(100, dtype=np.int32)
     movie_ids_1[:20] = np.unique(candidate_ids)[:20]
 
@@ -72,7 +73,7 @@ def test_run_dag_on_dataframe_with_local_executor():
         ]
     )
 
-    candidate_ids = np.random.randint(1, 100000, 100).astype(np.int32)
+    candidate_ids = np.array(random.sample(range(100000), 100), dtype=np.int32)
     movie_ids_1 = np.zeros(100, dtype=np.int32)
     movie_ids_1[:20] = np.unique(candidate_ids)[:20]
 
@@ -105,7 +106,7 @@ def test_run_dag_on_dataframe_with_dask_executor():
         ]
     )
 
-    candidate_ids = np.random.randint(1, 100000, 100).astype(np.int32)
+    candidate_ids = np.array(random.sample(range(100000), 100), dtype=np.int32)
     movie_ids_1 = np.zeros(100, dtype=np.int32)
     movie_ids_1[:20] = np.unique(candidate_ids)[:20]
 


### PR DESCRIPTION
Update random sampling in tests to impove test reliability.

Some of these tests are relying on some random sampling that relies on uniqueness of the sample (without replacement. Using `np.random.randint` which samples from a range with replacement allows duplicate values to crop up, causing test failures about 5% of the time.