### PR TITLE
update triton to allocate more cuda memory to pool size

### DIFF
--- a/merlin/systems/triton/utils.py
+++ b/merlin/systems/triton/utils.py
@@ -66,6 +66,7 @@ def run_triton_server(
         f"--backend-config={backend_config}",
         f"--grpc-port={grpc_port}",
         f"--grpc-address={grpc_host}",
+        "--cuda-memory-pool-byte-size=0:536870912",
     ]
     env = os.environ.copy()
     env["CUDA_VISIBLE_DEVICES"] = "0"


### PR DESCRIPTION
This will help stabilize the triton runtime fil op tests. It allows triton to allocate ~500MB instead of the default 64MB. This helps when loading models specifically FIL backend models.