### PR TITLE
Update API and add notebook

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -25,9 +25,23 @@ Ensemble Operator Constructors
 
    workflow.TransformWorkflow
    tensorflow.PredictTensorflow
+   fil.PredictForest
+   implicit.PredictImplicit
    softmax_sampling.SoftmaxSampling
    session_filter.FilterCandidates
    unroll_features.UnrollFeatures
 
 .. faiss.QueryFaiss
 .. feast.QueryFeast
+
+
+Conversion Functions for Triton Inference Server
+------------------------------------------------
+
+.. currentmodule:: merlin.systems.triton
+
+.. autosummary::
+   :toctree: generated
+
+   convert_df_to_triton_input
+   convert_triton_output_to_df

--- a/docs/source/toc.yaml
+++ b/docs/source/toc.yaml
@@ -11,5 +11,6 @@ subtrees:
             entries:
               - file: examples/Serving-Ranking-Models-With-Merlin-Systems.ipynb
               - file: examples/Serving-An-XGboost-Model-With-Merlin-Systems.ipynb
+              - file: examples/Serving-An-Implicit-Model-With-Merlin-Systems.ipynb
       - file: api
         title: API Documentation


### PR DESCRIPTION
- Update the API docs to include newer Operators, exporting functions for ensembles, and conversion functions for Triton Inference Server.

- Add the notebook that demonstrates how to serve an implicit model.