### PR TITLE
add import or skip for torch tests

### DIFF
--- a/tests/unit/systems/dag/runtimes/triton/ops/torch/__init__.py
+++ b/tests/unit/systems/dag/runtimes/triton/ops/torch/__init__.py
@@ -13,3 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import pytest
+
+pytest.importorskip("torch")


### PR DESCRIPTION
This PR adds the import or skip to init file of the torch tests to ensure we skip if framework is not available.