### PR TITLE
detect when column is list of one argument per record

### DIFF
--- a/merlin/systems/dag/dictarray.py
+++ b/merlin/systems/dag/dictarray.py
@@ -144,7 +144,11 @@ class Column(SeriesLike):
 
     @property
     def is_list(self):
-        return len(self.values.shape) > 1 or self.row_lengths is not None
+        return (
+            len(self.values.shape) > 1
+            or self.row_lengths is not None
+            or isinstance(self.values[0], np.ndarray)
+        )
 
     @property
     def is_ragged(self):

--- a/tests/unit/systems/dag/test_column.py
+++ b/tests/unit/systems/dag/test_column.py
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import numpy as np
+
+from merlin.systems.dag.dictarray import Column
+
+
+def test_column_scalar_list():
+    column = Column(np.array([[1], [2], [3]]))
+    assert column.is_list is True

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps = -rrequirements/test-cpu.txt
 commands =
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
     python -m pip install .
-    python -m pip install scikit-learn==1.1.3
+    
     python -m pytest --cov-report term --cov=merlin -rxs tests/unit
 
 [testenv:test-gpu]

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps = -rrequirements/test-cpu.txt
 commands =
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
     python -m pip install .
-    
+    python -m pip install scikit-learn==1.1.3
     python -m pytest --cov-report term --cov=merlin -rxs tests/unit
 
 [testenv:test-gpu]


### PR DESCRIPTION
Moves logic of detecting a scalar list into the column class. Along with a test.