### PR TITLE
Specify Minimum Python Version as 3.8 in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,10 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3 :: Only",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Topic :: Software Development :: Libraries",

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
         "Topic :: Scientific/Engineering",
     ],
     zip_safe=False,
+    python_requires=">=3.8",
     install_requires=requirements["cpu"],
     extras_require={
         **requirements,


### PR DESCRIPTION
- Specifes the minimum Python Version as 3.8.
- Add specific python versions to the classifiers configuratiuon to indicate the intended Python version compatibility of the package. 