### PR TITLE
Fix the Triton dtype of exported NVTabular workflow row length fields

### DIFF
--- a/merlin/systems/triton/export.py
+++ b/merlin/systems/triton/export.py
@@ -697,7 +697,7 @@ def _add_model_param(col_schema, paramclass, params, dims=None):
         )
         params.append(
             paramclass(
-                name=col_schema.name + "__lengths", data_type=model_config.TYPE_INT64, dims=dims
+                name=col_schema.name + "__lengths", data_type=model_config.TYPE_INT32, dims=dims
             )
         )
     else:


### PR DESCRIPTION
For consistency, it should be an INT32 everywhere.

Resolves #243 