### PR TITLE
Replace merlin.models.loader.tf_utils with merlin.dataloader.tf_utils

### DIFF
--- a/tests/integration/examples/test_serving_ranking_models_with_merlin_systems.py
+++ b/tests/integration/examples/test_serving_ranking_models_with_merlin_systems.py
@@ -102,7 +102,7 @@ def test_example_04_exporting_ranking_models(tb):
     )
     batch = batch.drop(columns="click")
     outputs = tb.ref("output_cols")
-    from merlin.models.loader.tf_utils import configure_tensorflow
+    from merlin.dataloader.tf_utils import configure_tensorflow
 
     configure_tensorflow()
     from merlin.systems.triton.utils import run_ensemble_on_tritonserver

--- a/tests/unit/systems/ops/faiss/test_executor.py
+++ b/tests/unit/systems/ops/faiss/test_executor.py
@@ -24,8 +24,8 @@ from merlin.systems.dag.ensemble import Ensemble
 from merlin.systems.dag.ops.faiss import QueryFaiss, setup_faiss
 
 TRITON_SERVER_PATH = find_executable("tritonserver")
-pytest.importorskip("merlin.models.loader.tf_utils")
-from merlin.models.loader.tf_utils import configure_tensorflow  # noqa
+pytest.importorskip("merlin.dataloader.tf_utils")
+from merlin.dataloader.tf_utils import configure_tensorflow  # noqa
 
 tritonclient = pytest.importorskip("tritonclient")
 grpcclient = pytest.importorskip("tritonclient.grpc")


### PR DESCRIPTION
`merlin.models.loader.tf_utils` has been replaced with `merlin.dataloader.tf_utils`.