### PR TITLE
adding async tf strategy for gpu memory

### DIFF
--- a/ci/test_unit.sh
+++ b/ci/test_unit.sh
@@ -18,6 +18,6 @@
 set -e
 
 # Run tests
-pytest -rsx tests/unit tests/notebook
+TF_GPU_ALLOCATOR=cuda_malloc_async pytest -rsx tests/unit tests/notebook
 
 


### PR DESCRIPTION
This adds the `TF_GPU_ALLOCATOR=cuda_malloc_async` env var to unit tests for container verification. To help avoid OOM GPU memory issues. 