### PR TITLE
Remove tf model from ensemble export

### DIFF
--- a/merlin/systems/dag/runtimes/triton/ops/tensorflow.py
+++ b/merlin/systems/dag/runtimes/triton/ops/tensorflow.py
@@ -48,6 +48,16 @@ class PredictTensorflowTriton(TritonOperator):
 
         self._tf_model_name = None
 
+    def __getstate__(self) -> dict:
+        """Return state of instance when pickled.
+
+        Returns
+        -------
+        dict
+            Returns object state excluding model attribute.
+        """
+        return {k: v for k, v in self.__dict__.items() if k != "model"}
+
     def transform(self, col_selector: ColumnSelector, transformable: Transformable):
         """Run transform of operator callling TensorFlow model with a Triton InferenceRequest.
 


### PR DESCRIPTION
This PR ensures that when cloudpickling the ensemble we do not also pickle the model in the PredictTensorflowTriton operator. This is  only occurs in tensorflow operator because we rely on the serving signature from the model, so we have to load the model to run validation on inputs and outputs. 