### PR TITLE
Update Systems to match the dataloader/models changes re: values/offsets

### DIFF
--- a/examples/Serving-Ranking-Models-With-Merlin-Systems.ipynb
+++ b/examples/Serving-Ranking-Models-With-Merlin-Systems.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "620dd990",
    "metadata": {},
    "outputs": [],

--- a/merlin/systems/dag/ops/__init__.py
+++ b/merlin/systems/dag/ops/__init__.py
@@ -15,7 +15,7 @@
 #
 
 
-def compute_dims(col_schema, scalar_shape=None):
+def compute_dims(col_schema):
     """
     Compute Triton dimensions for a column from its schema
 
@@ -23,8 +23,6 @@ def compute_dims(col_schema, scalar_shape=None):
     ----------
     col_schema : ColumnSchema
         Schema of the column to compute dimensions for
-    scalar_shape : List[int], optional
-        The shape of a single scalar element, by default None
 
     Returns
     -------
@@ -33,8 +31,12 @@ def compute_dims(col_schema, scalar_shape=None):
     """
     batch_dim = [-1]
 
-    default_scalar_shape = col_schema.properties.get("triton_scalar_shape", [1])
-    column_dims = scalar_shape if scalar_shape is not None else default_scalar_shape
+    # [] - UNAVAILABLE: Internal: unable to autofill for '1_predicttensorflowtriton', model tensor configurations are contradicting each other in terms of whether batching is supported
+    # [1] - UNAVAILABLE: Invalid argument: model '1_predicttensorflowtriton', tensor 'item_brand': the model expects 1 dimensions (shape [-1]) but the model configuration specifies 2 dimensions (shape [-1,1])
+    # [-1] - UNAVAILABLE: Invalid argument: model '1_predicttensorflowtriton', tensor 'item_brand': the model expects 1 dimensions (shape [-1]) but the model configuration specifies 2 dimensions (shape [-1,-1])
+    # [0] - Don't even get to Triton
+
+    column_dims = []
     assert isinstance(column_dims, list)
 
     if col_schema.is_list:

--- a/merlin/systems/dag/ops/pytorch.py
+++ b/merlin/systems/dag/ops/pytorch.py
@@ -60,19 +60,6 @@ class PredictPyTorch(InferenceOperator):
                 self.path = None
                 self.model = model_or_path
 
-            # This is a hack to enable the ensemble to use the same shape as this
-            # these lines mutate the input and output schema with the additional property
-            # `triton_scalar_shape` which represents the expected shape for this feature
-            for col_name, col_schema in self.input_schema.column_schemas.items():
-                self.input_schema[col_name] = col_schema.with_properties(
-                    {"triton_scalar_shape": self.scalar_shape}
-                )
-
-            for col_name, col_schema in self.output_schema.column_schemas.items():
-                self.output_schema[col_name] = col_schema.with_properties(
-                    {"triton_scalar_shape": self.scalar_shape}
-                )
-
     def __getstate__(self):
         return {k: v for k, v in self.__dict__.items() if k != "model"}
 

--- a/merlin/systems/dag/ops/tensorflow.py
+++ b/merlin/systems/dag/ops/tensorflow.py
@@ -148,14 +148,14 @@ class PredictTensorflow(InferenceOperator):
         input_schema = Schema()
         for col_name, col in default_signature.structured_input_signature[1].items():
             col_schema = ColumnSchema(col_name, dtype=col.dtype.as_numpy_dtype)
-            if col.shape[1] and col.shape[1] > 1:
+            if len(col.shape) > 1 and col.shape[1] and col.shape[1] > 1:
                 col_schema = self._set_list_length(col_schema, col.shape[1])
             input_schema.column_schemas[col_name] = col_schema
 
         output_schema = Schema()
         for col_name, col in default_signature.structured_outputs.items():
             col_schema = ColumnSchema(col_name, dtype=col.dtype.as_numpy_dtype)
-            if col.shape[1] and col.shape[1] > 1:
+            if len(col.shape) > 1 and col.shape[1] and col.shape[1] > 1:
                 col_schema = self._set_list_length(col_schema, col.shape[1])
             output_schema.column_schemas[col_name] = col_schema
 

--- a/merlin/systems/triton/export.py
+++ b/merlin/systems/triton/export.py
@@ -24,7 +24,7 @@ from merlin.core.dispatch import is_string_dtype  # noqa
 
 
 def _add_model_param(col_schema, paramclass, params, dims=None):
-    dims = dims if dims is not None else [-1, 1]
+    dims = dims if dims is not None else [-1]
     if col_schema.is_list and col_schema.is_ragged:
         params.append(
             paramclass(

--- a/tests/unit/systems/ops/tf/test_shape.py
+++ b/tests/unit/systems/ops/tf/test_shape.py
@@ -1,0 +1,132 @@
+import os
+
+import numpy as np
+import pytest
+import tensorflow as tf
+from testbook import testbook
+
+import merlin.models.tf as mm
+import nvtabular as nvt
+from merlin.datasets.synthetic import generate_data
+from merlin.io.dataset import Dataset
+from merlin.schema import Schema, Tags
+from merlin.schema.tags import Tags
+from merlin.systems.dag.ensemble import Ensemble
+from merlin.systems.dag.ops.tensorflow import PredictTensorflow
+from merlin.systems.dag.ops.workflow import TransformWorkflow
+from merlin.systems.triton.utils import run_ensemble_on_tritonserver  # noqa
+from nvtabular.workflow import Workflow
+from tests.conftest import REPO_ROOT
+
+pytest.importorskip("cudf")
+pytest.importorskip("tensorflow")
+pytest.importorskip("merlin.models")
+
+
+def test_model_input_shapes():
+    DATA_FOLDER = "/tmp/data/"
+    NUM_ROWS = 1000000
+    BATCH_SIZE = 512
+    train, valid = generate_data("aliccp-raw", int(NUM_ROWS), set_sizes=(0.7, 0.3))
+    train.to_ddf().to_parquet(os.path.join(DATA_FOLDER, "train"))
+    valid.to_ddf().to_parquet(os.path.join(DATA_FOLDER, "valid"))
+    train_path = os.path.join(DATA_FOLDER, "train", "*.parquet")
+    valid_path = os.path.join(DATA_FOLDER, "valid", "*.parquet")
+    output_path = os.path.join(DATA_FOLDER, "processed")
+    user_id = ["user_id"] >> nvt.ops.Categorify() >> nvt.ops.TagAsUserID()
+    item_id = ["item_id"] >> nvt.ops.Categorify() >> nvt.ops.TagAsItemID()
+    targets = ["click"] >> nvt.ops.AddMetadata(tags=[Tags.BINARY_CLASSIFICATION, "target"])
+    item_features = (
+        ["item_category", "item_shop", "item_brand"]
+        >> nvt.ops.Categorify()
+        >> nvt.ops.TagAsItemFeatures()
+    )
+    user_features = (
+        [
+            "user_shops",
+            "user_profile",
+            "user_group",
+            "user_gender",
+            "user_age",
+            "user_consumption_2",
+            "user_is_occupied",
+            "user_geography",
+            "user_intentions",
+            "user_brands",
+            "user_categories",
+        ]
+        >> nvt.ops.Categorify()
+        >> nvt.ops.TagAsUserFeatures()
+    )
+    outputs = user_id + item_id + item_features + user_features + targets
+    workflow = nvt.Workflow(outputs)
+    train_dataset = nvt.Dataset(train_path)
+    valid_dataset = nvt.Dataset(valid_path)
+    workflow.fit(train_dataset)
+    workflow.transform(train_dataset).to_parquet(output_path=output_path + "/train/")
+    workflow.transform(valid_dataset).to_parquet(output_path=output_path + "/valid/")
+    workflow.save("/tmp/data/workflow")
+    train = Dataset(os.path.join(output_path, "train", "*.parquet"))
+    valid = Dataset(os.path.join(output_path, "valid", "*.parquet"))
+    schema = train.schema
+    target_column = schema.select_by_tag(Tags.TARGET).column_names[0]
+    model = mm.DLRMModel(
+        schema,
+        embedding_dim=64,
+        bottom_block=mm.MLPBlock([128, 64]),
+        top_block=mm.MLPBlock([128, 64, 32]),
+        prediction_tasks=mm.BinaryClassificationTask(target_column),
+    )
+    model.compile("adam", run_eagerly=False, metrics=[tf.keras.metrics.AUC()])
+    model.fit(train, validation_data=valid, batch_size=BATCH_SIZE)
+    model.save("/tmp/data/dlrm")
+
+    os.environ["TF_GPU_ALLOCATOR"] = "cuda_malloc_async"
+    input_path = DATA_FOLDER
+
+    workflow_stored_path = os.path.join(input_path, "workflow")
+
+    workflow = Workflow.load(workflow_stored_path)
+
+    label_columns = workflow.output_schema.select_by_tag(Tags.TARGET).column_names
+    workflow.remove_inputs(label_columns)
+
+    tf_model_path = os.path.join(input_path, "dlrm")
+
+    model = tf.keras.models.load_model(tf_model_path)
+
+    serving_operators = (
+        workflow.input_schema.column_names
+        >> TransformWorkflow(workflow)
+        >> PredictTensorflow(model)
+    )
+
+    ensemble = Ensemble(serving_operators, workflow.input_schema)
+    export_path = os.path.join(input_path, "ensemble")
+    ens_conf, node_confs = ensemble.export(export_path)
+
+    from merlin.core.dispatch import get_lib
+
+    df_lib = get_lib()
+
+    original_data_path = DATA_FOLDER
+
+    # read in data for request
+    batch = df_lib.read_parquet(
+        os.path.join(original_data_path, "valid", "part.0.parquet"),
+        num_rows=3,
+        columns=workflow.input_schema.column_names,
+    )
+
+    response = run_ensemble_on_tritonserver(
+        export_path,
+        workflow.input_schema,
+        batch,
+        ensemble.graph.output_schema.column_names,
+        ens_conf.name,
+    )
+
+    breakpoint()
+
+    # for col in ensemble.graph.output_schema.column_names:
+    #     print(col, response[col], response[col].shape)


### PR DESCRIPTION
So far, we've figured out how to adjust the `PredictTensorflow` operator to match the updated shapes for scalar columns. That has probably broken other parts of Systems and there's definitely a bunch of refactoring to do to clean things up.