### PR TITLE
Remove the extra columns validation from `WorkflowRunner`

### DIFF
--- a/merlin/systems/workflow/base.py
+++ b/merlin/systems/workflow/base.py
@@ -60,15 +60,10 @@ class WorkflowRunner(ABC):
         workflow_outputs = set(workflow.output_schema.column_names)
         requested_cols = set(self.cats + self.conts)
         missing_cols = requested_cols - workflow_outputs
-        extra_cols = workflow_outputs - requested_cols
 
         if missing_cols:
             raise ValueError(
                 f"The following columns were not found in the workflow's output: {missing_cols}"
-            )
-        if extra_cols:
-            raise ValueError(
-                f"The following extra columns were found in the workflow's output: {extra_cols}"
             )
 
         # recurse over all column groups, initializing operators for inference pipeline


### PR DESCRIPTION
This was initially added in order to validate that the workflow was compatible with Triton ensembles, which we no longer use as the mechanism of composing operators. (Triton ensembles are very picky about having every Triton model only create columns that are used downstream.)