### PR TITLE
Update `SoftmaxSampling` to support dynamic dtypes

### DIFF
--- a/merlin/systems/dag/ops/softmax_sampling.py
+++ b/merlin/systems/dag/ops/softmax_sampling.py
@@ -101,8 +101,14 @@ class SoftmaxSampling(InferenceOperator):
         """Describe the operator's outputs"""
         return Schema(
             [
-                ColumnSchema("ordered_ids", dtype=np.int32, dims=(None, 1)),
-                ColumnSchema("ordered_scores", dtype=np.float32, dims=(None, 1)),
+                ColumnSchema(
+                    "ordered_ids", dtype=input_schema[self._input_col_name].dtype, dims=(None, 1)
+                ),
+                ColumnSchema(
+                    "ordered_scores",
+                    dtype=input_schema[self._relevance_col_name].dtype,
+                    dims=(None, 1),
+                ),
             ]
         )
 


### PR DESCRIPTION
Update `SoftmaxSampling` to support dynamic dtypes.

Currently the output schema of the SoftmaxSampling operator returns static dtypes which does not match the data returned when the operator is called with different dtypes from these.

This update the `compute_output_schema` method to match the implementation of `transform`. It returns ids and scores with the corresponding dtypes of the input ids and scores.

Alternatively, we could update the `transform` method to coerce the outputs to match the static types. However, it feels to me that matching the types passed in could feel more natural, as it would match the behaviour or array and tensor processing libraries, which typically return the same type as came in unless specified explicitly with a cast or extra parameter.