### PR TITLE
Downgrade unused columns error to a warning

### DIFF
--- a/merlin/systems/dag/node.py
+++ b/merlin/systems/dag/node.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import os
+import warnings
 from typing import Union
 
 from merlin.dag import Node
@@ -96,7 +97,8 @@ class InferenceNode(Node):
                 sink_col_schema = childrens_schema.get(col_name)
 
                 if not sink_col_schema:
-                    raise ValueError(
-                        f"Output column '{col_name}' not detected in any "
-                        f"child inputs for '{self.op.__class__.__name__}'."
+                    warnings.warn(
+                        f"Operator '{self.op.__class__.__name__}' is producing the output column "
+                        f"'{col_name}', which is not being used by any downstream operator "
+                        f"in the ensemble graph."
                     )


### PR DESCRIPTION
Creating columns you don't use is still a bad idea, but it used to crash Triton when we were using Triton ensembles and now is mostly just going to cause the user headaches when they need to supply information that isn't actually used. Downgrading it to a warning will let people do this but still signal that it's a bad idea.