### PR TITLE
remove numpy conversion for cpu based data

### DIFF
--- a/merlin/systems/dag/ops/tensorflow.py
+++ b/merlin/systems/dag/ops/tensorflow.py
@@ -26,7 +26,7 @@ from merlin.core.protocols import Transformable  # noqa
 from merlin.dag import ColumnSelector  # noqa
 from merlin.schema import ColumnSchema, Schema  # noqa
 from merlin.systems.dag.ops.operator import InferenceOperator  # noqa
-from merlin.table import Device, NumpyColumn, TensorflowColumn, TensorTable  # noqa
+from merlin.table import TensorflowColumn, TensorTable  # noqa
 from merlin.table.conversions import convert_col  # noqa
 
 
@@ -90,7 +90,7 @@ class PredictTensorflow(InferenceOperator):
         if not isinstance(transformable, TensorTable):
             transformable = TensorTable.from_df(transformable)
 
-        col_type = TensorflowColumn if Device.GPU == transformable.device else NumpyColumn
+        col_type = TensorflowColumn
 
         tf_columns = {
             col_name: convert_col(column, col_type) for col_name, column in transformable.items()


### PR DESCRIPTION
This PR removes the numpy conversion logic in the local tensorflow op. It was added to circumvent an issue where we were segfaulting on certain tests in the cpu environment. However a fix was placed in core with https://github.com/NVIDIA-Merlin/core/pull/271. So we can remove this logic.