### PR TITLE
Revert "Remove the Triton-specific Workflow execution code (#309)"

### DIFF
--- a/merlin/systems/dag/runtimes/triton/ops/workflow.py
+++ b/merlin/systems/dag/runtimes/triton/ops/workflow.py
@@ -1,0 +1,301 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import importlib.resources
+import json
+import os
+import pathlib
+from shutil import copyfile
+
+import tritonclient.grpc.model_config_pb2 as model_config
+import tritonclient.utils
+from google.protobuf import text_format
+
+from merlin.core.protocols import Transformable
+from merlin.dag import ColumnSelector
+from merlin.schema import ColumnSchema, Schema
+from merlin.systems.dag.runtimes.triton.ops.operator import TritonOperator
+from merlin.systems.triton.conversions import (
+    tensor_table_to_triton_request,
+    triton_response_to_tensor_table,
+)
+from merlin.systems.triton.export import _add_model_param, _convert_dtype
+
+
+class TransformWorkflowTriton(TritonOperator):
+    """
+    This operator takes a workflow and turns it into a ensemble operator so that we can
+    execute feature engineering during ensemble on tritonserver.
+    """
+
+    def __init__(self, op):
+        """
+        Creates a Transform Workflow operator for a target workflow.
+
+        Parameters
+        ----------
+        workflow : Nvtabular.Workflow
+            The workflow to transform data in ensemble.
+        sparse_max : dict, optional
+            Dictionary representing key(name)/val(max value) pairs of max sparsity, by default None
+        max_batch_size : int, optional
+            Maximum batch size, by default None
+        label_columns : List[str], optional
+            List of strings identifying the label columns, by default None
+        model_framework : str, optional
+            String representing the target framework
+            (supported: hugectr, tensorflow, pytorch, python), by default None
+        cats : List[str], optional
+            List of strings identifying categorical columns, by default None
+        conts : List[str], optional
+            List of string identifying continuous columns, by default None
+        """
+        super().__init__(op)
+
+        self._nvt_model_name = None
+
+        if op.workflow is not None:
+            self.input_schema = op.workflow.input_schema
+            self.output_schema = op.workflow.output_schema
+
+    def transform(self, col_selector: ColumnSelector, transformable: Transformable):
+        """Transform the dataframe by applying this FIL operator to the set of input columns.
+
+        Parameters
+        -----------
+        df: TensorTable
+            A pandas or cudf dataframe that this operator will work on
+
+        Returns
+        -------
+        TensorTable
+            Returns a transformed dataframe for this operator"""
+        inference_request = tensor_table_to_triton_request(
+            self._nvt_model_name,
+            transformable,
+            self.input_schema.column_names,
+            self.output_schema.column_names,
+        )
+
+        inference_response = inference_request.exec()
+
+        # check inference response for errors:
+        if inference_response.has_error():
+            # Cannot raise inference response error because it is not derived from BaseException
+            raise tritonclient.utils.InferenceServerException(
+                str(inference_response.error().message())
+            )
+
+        return triton_response_to_tensor_table(
+            inference_response, type(transformable), self.output_schema.column_names
+        )
+
+    @classmethod
+    def from_config(cls, config: dict, **kwargs) -> "TransformWorkflowTriton":
+        """Instantiate the class from a dictionary representation.
+
+        Expected structure:
+        {
+            "input_dict": str  # JSON dict with input names and schemas
+            "params": str  # JSON dict with params saved at export
+        }
+
+        """
+        # Input schema
+        input_column_schemas = [
+            ColumnSchema(name, **schema_properties)
+            for name, schema_properties in json.loads(config["input_dict"]).items()
+        ]
+        input_schema = Schema(input_column_schemas)
+
+        # Output schema
+        output_column_schemas = [
+            ColumnSchema(name, **schema_properties)
+            for name, schema_properties in json.loads(config["output_dict"]).items()
+        ]
+        output_schema = Schema(output_column_schemas)
+        cls_instance = cls(None)
+        cls_instance.input_schema = input_schema
+        cls_instance.output_schema = output_schema
+
+        params = json.loads(config["params"])
+        cls_instance.set_nvt_model_name(params["nvt_model_name"])
+
+        return cls_instance
+
+    @property
+    def nvt_model_name(self):
+        """The name of the model held by the operator"""
+        return self._nvt_model_name
+
+    def set_nvt_model_name(self, nvt_model_name):
+        """Set the name of the model held by the operator"""
+        self._nvt_model_name = nvt_model_name
+
+    def compute_output_schema(
+        self, input_schema: Schema, col_selector: ColumnSelector, prev_output_schema: Schema = None
+    ) -> Schema:
+        """Returns output schema of operator"""
+        return self.op.workflow.output_schema
+
+    def export(
+        self,
+        path: str,
+        input_schema: Schema,
+        output_schema: Schema,
+        params: dict = None,
+        node_id: int = None,
+        version: int = 1,
+    ):
+        """Create a directory inside supplied path based on our export name"""
+        modified_workflow = self.op.workflow.remove_inputs(self.op.label_columns)
+        export_name = self.__class__.__name__.lower()
+        node_name = f"{node_id}_{export_name}" if node_id is not None else export_name
+        self.set_nvt_model_name(node_name)
+        node_export_path = pathlib.Path(path) / node_name
+        node_export_path.mkdir(parents=True, exist_ok=True)
+
+        backend_model_config = _generate_nvtabular_model(
+            modified_workflow,
+            node_name,
+            node_export_path,
+            sparse_max=self.op.sparse_max,
+            max_batch_size=self.op.max_batch_size,
+            cats=self.op.cats,
+            conts=self.op.conts,
+        )
+
+        return backend_model_config
+
+
+def _generate_nvtabular_model(
+    workflow,
+    name,
+    output_path,
+    version=1,
+    output_model=None,
+    max_batch_size=None,
+    sparse_max=None,
+    backend="python",
+    cats=None,
+    conts=None,
+):
+    """converts a workflow to a triton mode
+    Parameters
+    ----------
+    sparse_max:
+        Max length of the each row when the sparse data is converted to dense
+    cats:
+        Names of the categorical columns
+    conts:
+        Names of the continuous columns
+    """
+    workflow.save(os.path.join(output_path, str(version), "workflow"))
+    config = _generate_nvtabular_config(
+        workflow,
+        name,
+        output_path,
+        output_model,
+        max_batch_size,
+        sparse_max=sparse_max,
+        backend=backend,
+        cats=cats,
+        conts=conts,
+    )
+
+    # copy the model file over. note that this isn't necessary with the c++ backend, but
+    # does provide us to use the python backend with just changing the 'backend' parameter
+    with importlib.resources.path(
+        "merlin.systems.triton.models", "workflow_model.py"
+    ) as workflow_model:
+        copyfile(
+            workflow_model,
+            os.path.join(output_path, str(version), "model.py"),
+        )
+
+    return config
+
+
+def _generate_nvtabular_config(
+    workflow,
+    name,
+    output_path,
+    output_model=None,
+    max_batch_size=None,
+    sparse_max=None,
+    backend="python",
+    cats=None,
+    conts=None,
+):
+    """given a workflow generates the trton modelconfig proto object describing the inputs
+    and outputs to that workflow"""
+    config = model_config.ModelConfig(name=name, backend=backend, max_batch_size=max_batch_size)
+
+    config.parameters["python_module"].string_value = "merlin.systems.triton.models.workflow_model"
+    config.parameters["output_model"].string_value = output_model if output_model else ""
+
+    config.parameters["cats"].string_value = json.dumps(cats) if cats else ""
+    config.parameters["conts"].string_value = json.dumps(conts) if conts else ""
+
+    if sparse_max:
+        # this assumes seq_length is same for each list column
+        config.parameters["sparse_max"].string_value = json.dumps(sparse_max)
+
+    if output_model == "hugectr":
+        config.instance_group.append(model_config.ModelInstanceGroup(kind=2))
+
+        for column in workflow.output_node.input_columns.names:
+            dtype = workflow.input_dtypes[column]
+            config.input.append(
+                model_config.ModelInput(name=column, data_type=_convert_dtype(dtype), dims=[-1])
+            )
+
+        config.output.append(
+            model_config.ModelOutput(name="DES", data_type=model_config.TYPE_FP32, dims=[-1])
+        )
+
+        config.output.append(
+            model_config.ModelOutput(name="CATCOLUMN", data_type=model_config.TYPE_INT64, dims=[-1])
+        )
+
+        config.output.append(
+            model_config.ModelOutput(name="ROWINDEX", data_type=model_config.TYPE_INT32, dims=[-1])
+        )
+    elif output_model == "pytorch":
+        for col_name, col_schema in workflow.input_schema.column_schemas.items():
+            _add_model_param(col_schema, model_config.ModelInput, config.input)
+
+        for col_name, col_schema in workflow.output_schema.column_schemas.items():
+            _add_model_param(
+                col_schema,
+                model_config.ModelOutput,
+                config.output,
+                [-1, 1],
+            )
+    else:
+        for col_name, col_schema in workflow.input_schema.column_schemas.items():
+            _add_model_param(col_schema, model_config.ModelInput, config.input)
+
+        for col_name, col_schema in workflow.output_schema.column_schemas.items():
+            if sparse_max and col_name in sparse_max.keys():
+                # this assumes max_sequence_length is equal for all output columns
+                dim = sparse_max[col_name]
+                _add_model_param(col_schema, model_config.ModelOutput, config.output, [-1, dim])
+            else:
+                _add_model_param(col_schema, model_config.ModelOutput, config.output)
+
+    with open(os.path.join(output_path, "config.pbtxt"), "w", encoding="utf-8") as o:
+        text_format.PrintMessage(config, o)
+    return config

--- a/merlin/systems/dag/runtimes/triton/runtime.py
+++ b/merlin/systems/dag/runtimes/triton/runtime.py
@@ -31,8 +31,10 @@ from merlin.systems.dag.ops.compat import (
     treelite_sklearn,
     xgboost,
 )
+from merlin.systems.dag.ops.workflow import TransformWorkflow
 from merlin.systems.dag.runtimes import Runtime
 from merlin.systems.dag.runtimes.triton.ops.operator import TritonOperator, add_model_param
+from merlin.systems.dag.runtimes.triton.ops.workflow import TransformWorkflowTriton
 
 tensorflow = None
 try:
@@ -52,6 +54,7 @@ except ImportError:
 
 
 TRITON_OP_TABLE = {}
+TRITON_OP_TABLE[TransformWorkflow] = TransformWorkflowTriton
 
 if cuml_ensemble or lightgbm or sklearn_ensemble or treelite_sklearn or xgboost:
     from merlin.systems.dag.ops.fil import PredictForest

--- a/merlin/systems/workflow/__init__.py
+++ b/merlin/systems/workflow/__init__.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from merlin.schema import Tags
+
+
+def get_embedding_sizes(source, output_dtypes=None):
+    """Returns a dictionary of embedding sizes from a workflow or workflow_node
+
+    Parameters
+    ----------
+    source : Workflow or ColumnSelector
+        Either a nvtabular Workflow or ColumnSelector object that we should use to find
+        embedding sizes
+    output_dtypes : dict, optional
+        Optional dictionary of column_name:dtype. If passing a workflow object dtypes
+        will be read from the workflow. This is used to figure out which columns
+        are multihot-categorical, which are split out by this function. If passed a workflow_node
+        and this parameter isn't set, you won't have multihot columns returned separately
+    """
+    # TODO: do we need to distinguish multihot columns here?  (if so why? )
+
+    # have to lazy import Workflow to avoid circular import errors
+    from nvtabular.workflow import Workflow
+
+    output_node = source.output_node if isinstance(source, Workflow) else source
+
+    if isinstance(source, Workflow):
+        output_dtypes = output_dtypes or source.output_dtypes
+    else:
+        # passed in a column group
+        output_dtypes = output_dtypes or {}
+
+    output = {}
+    multihot_columns = set()
+    cats_schema = output_node.output_schema.select_by_tag(Tags.CATEGORICAL)
+    for col_name, col_schema in cats_schema.column_schemas.items():
+        if col_schema.dtype and col_schema.is_list and col_schema.is_ragged:
+            # multi hot so remove from output and add to multihot
+            multihot_columns.add(col_name)
+
+        embeddings_sizes = col_schema.properties.get("embedding_sizes", {})
+        cardinality = embeddings_sizes["cardinality"]
+        dimensions = embeddings_sizes["dimension"]
+        output[col_name] = (cardinality, dimensions)
+
+    # TODO: returning different return types like this (based off the presence
+    # of multihot features) is pretty janky. fix.
+    if not multihot_columns:
+        return output
+
+    single_hots = {k: v for k, v in output.items() if k not in multihot_columns}
+    multi_hots = {k: v for k, v in output.items() if k in multihot_columns}
+    return single_hots, multi_hots

--- a/merlin/systems/workflow/base.py
+++ b/merlin/systems/workflow/base.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import functools
+import json
+import logging
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+from merlin.core.dispatch import concat_columns
+from merlin.dag import ColumnSelector, Supports
+from merlin.schema import Tags
+from merlin.systems.triton.conversions import convert_format
+
+LOG = logging.getLogger("merlin-systems")
+
+
+class WorkflowRunner(ABC):
+    def __init__(self, workflow, output_dtypes, model_config, model_device):
+        self.workflow = workflow
+        self.output_dtypes = output_dtypes
+        self.model_config = model_config
+        self.device = model_device
+
+        output_schema = self.workflow.output_schema
+
+        schema_cats = output_schema.apply(ColumnSelector(tags=[Tags.CATEGORICAL])).column_names
+        schema_conts = output_schema.apply(ColumnSelector(tags=[Tags.CONTINUOUS])).column_names
+
+        mc_cats = json.loads(self._get_param(model_config, "cats", "string_value", default="[]"))
+        mc_conts = json.loads(self._get_param(model_config, "conts", "string_value", default="[]"))
+
+        self.cats = mc_cats or schema_cats
+        self.conts = mc_conts or schema_conts
+
+        workflow_outputs = set(workflow.output_schema.column_names)
+        requested_cols = set(self.cats + self.conts)
+        missing_cols = requested_cols - workflow_outputs
+
+        if missing_cols:
+            raise ValueError(
+                f"The following columns were not found in the workflow's output: {missing_cols}"
+            )
+
+        # recurse over all column groups, initializing operators for inference pipeline
+        self._initialize_ops(self.workflow.output_node)
+
+    def _initialize_ops(self, workflow_node, visited=None):
+        if visited is None:
+            visited = set()
+
+        if workflow_node.op and hasattr(workflow_node.op, "inference_initialize"):
+            inference_op = workflow_node.op.inference_initialize(
+                workflow_node.selector, self.model_config
+            )
+            if inference_op:
+                workflow_node.op = inference_op
+
+            supported = workflow_node.op.supports
+
+            # if we're running on the CPU only, mask off support for GPU data formats
+            if self.device == "CPU":
+                supported = functools.reduce(
+                    lambda a, b: a | b,
+                    (v for v in list(Supports) if v & supported and "CPU" in str(v)),
+                )
+            # the 'supports' property is readonly, and we can't always attach a new property
+            # to some of the operators (C++ categorify etc). set on the workflow_node instead
+            workflow_node.inference_supports = supported
+
+        for parent in workflow_node.parents_with_dependencies:
+            if parent not in visited:
+                visited.add(parent)
+                self._initialize_ops(parent, visited)
+
+    def run_workflow(self, input_tensors):
+        # use our NVTabular workflow to transform the dataset
+        transformed, kind = self._transform_tensors(input_tensors, self.workflow.output_node)
+
+        # if we don't have tensors in numpy format, convert back so that the we can return
+        # to triton
+        if kind != Supports.CPU_DICT_ARRAY:
+            transformed, kind = convert_format(transformed, kind, Supports.CPU_DICT_ARRAY)
+
+        # convert to the format expected by the DL models
+        return self._transform_outputs(transformed)
+
+    @abstractmethod
+    def _transform_outputs(self, tensors):
+        pass
+
+    def _convert_to_np(self, columns, tensors, dtype, rows):
+        """converts outputs to a numpy input compatible with pytorch"""
+        d = np.empty((rows, len(columns)), dtype=dtype)
+        for i, name in enumerate(columns):
+            d[:, i] = tensors[name].astype(dtype)
+        return d
+
+    def _transform_tensors(self, input_tensors, workflow_node):
+        upstream_inputs = []
+
+        # Gather inputs from the parents and dependency nodes
+        if workflow_node.parents_with_dependencies:
+            for parent in workflow_node.parents_with_dependencies:
+                upstream_tensors, upstream_kind = self._transform_tensors(input_tensors, parent)
+                if upstream_tensors is not None and upstream_kind:
+                    upstream_inputs.append((upstream_tensors, upstream_kind))
+
+        # Gather additional input columns from the original input tensors
+        if workflow_node.selector:
+            selector_columns = workflow_node.selector.names
+            to_remove = []
+            for upstream_tensors, upstream_kind in upstream_inputs:
+                for col in selector_columns:
+                    if col in upstream_tensors:
+                        to_remove.append(col)
+            for col in set(to_remove):
+                selector_columns.remove(col)
+
+            if selector_columns:
+                selected_tensors = {c: input_tensors[c] for c in selector_columns}
+                selected_kinds = Supports.CPU_DICT_ARRAY
+                upstream_inputs.append((selected_tensors, selected_kinds))
+
+        # Standardize the formats
+        tensors, kind = None, None
+        for upstream_tensors, upstream_kind in upstream_inputs:
+            if tensors is None:
+                tensors, kind = upstream_tensors, upstream_kind
+            else:
+                if kind != upstream_kind:
+                    # we have multiple different kinds of data here (dataframe/array on cpu/gpu)
+                    # we need to convert to a common format here first before concatenating.
+                    op = workflow_node.op
+                    if op and hasattr(op, "inference_supports"):
+                        target_kind = op.inference_supports
+                    else:
+                        target_kind = Supports.CPU_DICT_ARRAY
+                    # note : the 2nd convert_format call needs to be stricter in what the kind is
+                    # (exact match rather than a bitmask of values)
+                    tensors, kind = convert_format(tensors, kind, target_kind)
+                    upstream_tensors, _ = convert_format(upstream_tensors, upstream_kind, kind)
+
+                tensors = self.concat_tensors([tensors, upstream_tensors], kind)
+
+        # Run the transform
+        if tensors is not None and kind and workflow_node.op:
+            try:
+                # if the op doesn't support the current kind - we need to convert
+                if (
+                    hasattr(workflow_node, "inference_supports")
+                    and not workflow_node.inference_supports & kind
+                ):
+                    tensors, kind = convert_format(tensors, kind, workflow_node.inference_supports)
+
+                tensors = workflow_node.op.transform(
+                    workflow_node.input_columns,
+                    tensors,
+                )
+
+            except Exception:
+                LOG.exception("Failed to transform operator %s", workflow_node.op)
+                raise
+
+        return tensors, kind
+
+    def concat_tensors(self, tensors, kind):
+        if kind & (Supports.GPU_DATAFRAME | Supports.CPU_DATAFRAME):
+            return concat_columns(tensors)
+        else:
+            output = tensors[0]
+            for tensor in tensors[1:]:
+                output.update(tensor)
+            return output
+
+    def _get_param(self, config, *args, default=None):
+        config_element = config["parameters"]
+        for key in args:
+            config_element = config_element.get(key, {})
+        return config_element or default

--- a/merlin/systems/workflow/hugectr.py
+++ b/merlin/systems/workflow/hugectr.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import numpy as np
+
+from merlin.systems.workflow import get_embedding_sizes
+from merlin.systems.workflow.base import WorkflowRunner
+
+
+class HugeCTRWorkflowRunner(WorkflowRunner):
+    def __init__(self, workflow, output_dtypes, model_config, model_device):
+        super().__init__(workflow, output_dtypes, model_config, model_device)
+
+        if self.cats:
+            self.offsets = self.get_offsets(self.workflow, self.cats)
+
+    def _transform_outputs(self, tensors):
+        output_tensors = []
+        if self.conts:
+            output_tensors.append(
+                (
+                    "DES",
+                    self._convert(self.conts, tensors, np.float32),
+                )
+            )
+        else:
+            output_tensors.append(("DES", np.array([[]], np.float32)))
+
+        if self.cats:
+            for name in self.cats:
+                tensors[name] += self.offsets[name]
+            cats_np = self._convert(self.cats, tensors, np.int64)
+            output_tensors.append(
+                (
+                    "CATCOLUMN",
+                    cats_np,
+                )
+            )
+        else:
+            output_tensors.append(("CATCOLUMN", np.array([[]], np.int64)))
+
+        len_cats_np = cats_np.shape[1]
+        row_index = np.arange(len_cats_np + 1, dtype=np.int32).reshape(1, len_cats_np + 1)
+        output_tensors.append(("ROWINDEX", row_index))
+
+        return output_tensors
+
+    def _convert(self, columns, tensors, dtype):
+        """converts outputs to a numpy input compatible with hugectr"""
+        rows = max(len(tensors[name]) for name in columns)
+        d = self._convert_to_np(columns, tensors, dtype, rows)
+        return d.reshape(1, len(columns) * rows)
+
+    def get_offsets(self, workflow, categorical_cols):
+        embeddings = get_embedding_sizes(workflow)
+        if embeddings is None:
+            raise Exception("embeddings cannot be None")
+        else:
+            offsets = {}
+            curr_offset = 0
+            for name in categorical_cols:
+                offsets[name] = curr_offset
+                curr_offset += embeddings[name][0]
+            return offsets

--- a/merlin/systems/workflow/pytorch.py
+++ b/merlin/systems/workflow/pytorch.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from merlin.systems.workflow.base import WorkflowRunner
+
+
+class PyTorchWorkflowRunner(WorkflowRunner):
+    def _transform_outputs(self, tensors):
+        output_tensors = []
+        for col_name in self.cats + self.conts:
+            output_tensors.append(
+                (
+                    col_name,
+                    self._convert([col_name], tensors, self.workflow.output_dtypes[col_name]),
+                )
+            )
+
+        return output_tensors
+
+    def _convert(self, columns, tensors, dtype):
+        """converts outputs to a numpy input compatible with pytorch"""
+        rows = max(len(tensors[name]) for name in columns)
+        return self._convert_to_np(columns, tensors, dtype, rows)

--- a/merlin/systems/workflow/tensorflow.py
+++ b/merlin/systems/workflow/tensorflow.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import json
+
+from merlin.systems.workflow.base import WorkflowRunner
+
+
+class TensorflowWorkflowRunner(WorkflowRunner):
+    def __init__(self, workflow, output_dtypes, model_config, model_device):
+        super().__init__(workflow, output_dtypes, model_config, model_device)
+
+        self.offsets = None
+
+    def _transform_outputs(self, tensors):
+        # Load extra info needed for the Transformer4Rec (if exists)
+        sparse_feat = None
+        params = self.model_config["parameters"]
+        if "sparse_max" in params.keys():
+            sparse_feat = json.loads(self.model_config["parameters"]["sparse_max"]["string_value"])
+        # transforms outputs for both pytorch and tensorflow
+        output_tensors = []
+        for name in self.cats + self.conts:
+            value = tensors[name]
+            if sparse_feat and name in sparse_feat.keys():
+                # convert sparse tensors to dense representations
+                d = value[0].astype(self.output_dtypes[name])
+                col_dim = sparse_feat[name]
+                row_dim = d.shape[0] // col_dim
+                d = d.reshape(row_dim, col_dim)
+                output_tensors.append((name, d))
+            elif isinstance(value, tuple):
+                # convert list values to match TF dataloader
+                values = value[0].astype(self.output_dtypes[name + "__values"])
+                output_tensors.append((name + "__values", values))
+
+                offsets = value[1].astype(self.output_dtypes[name + "__offsets"])
+                output_tensors.append((name + "__offsets", offsets))
+            else:
+                d = value.astype(self.output_dtypes[name])
+                output_tensors.append((name, d))
+        return output_tensors

--- a/tests/unit/systems/ops/fil/test_forest.py
+++ b/tests/unit/systems/ops/fil/test_forest.py
@@ -131,10 +131,15 @@ def test_ensemble(tmpdir):
 
     triton_ens.export(tmpdir)
 
-    config_path = tmpdir / "0_filtriton" / "config.pbtxt"
+    config_path = tmpdir / "1_filtriton" / "config.pbtxt"
     parsed_config = read_config(config_path)
-    assert "0_fil" in parsed_config.name
+    assert "1_fil" in parsed_config.name
     assert parsed_config.backend == "fil"
+
+    config_path = tmpdir / "0_transformworkflowtriton" / "config.pbtxt"
+    parsed_config = read_config(config_path)
+    assert "0_transformworkflow" in parsed_config.name
+    assert parsed_config.backend == "python"
 
     config_path = tmpdir / "executor_model" / "config.pbtxt"
     parsed_config = read_config(config_path)


### PR DESCRIPTION
This reverts commit f3541f6136cb065c92e432a8adc30869d16e9c93.

Removing the Triton-specific Workflow execution code bypassed the code that explicitly saved the Workflow out to a sub-directory of the Triton model repository, which had the side-effect of not saving the Categorify category files. The tests still passed because the Workflow is also pickled inside the Ensemble, and we don't have any tests that:
* Run a Workflow containing a Categorify
* Change the current working directory after fitting the Workflow

...both of which are required to reproduce the issue with loading category files since fitting a Workflow has the side effect of writing category files out to the current working directory.