### PR TITLE
Make minor adjustments to the way `Workflow` outputs are formatted

### DIFF
--- a/merlin/systems/workflow/tensorflow.py
+++ b/merlin/systems/workflow/tensorflow.py
@@ -25,6 +25,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import json
 
+import numpy as np
+
 from merlin.systems.workflow.base import WorkflowRunner
 
 
@@ -40,8 +42,10 @@ class TensorflowWorkflowRunner(WorkflowRunner):
         params = self.model_config["parameters"]
         if "sparse_max" in params.keys():
             sparse_feat = json.loads(self.model_config["parameters"]["sparse_max"]["string_value"])
+
         # transforms outputs for both pytorch and tensorflow
         output_tensors = []
+
         for name in self.cats + self.conts:
             value = tensors[name]
             if sparse_feat and name in sparse_feat.keys():
@@ -53,10 +57,10 @@ class TensorflowWorkflowRunner(WorkflowRunner):
                 output_tensors.append((name, d))
             elif isinstance(value, tuple):
                 # convert list values to match TF dataloader
-                values = value[0].astype(self.output_dtypes[name + "__values"])
+                values = value[0].astype(self.output_dtypes[name])
                 output_tensors.append((name + "__values", values))
 
-                offsets = value[1].astype(self.output_dtypes[name + "__offsets"])
+                offsets = value[1].astype(np.int32)
                 output_tensors.append((name + "__offsets", offsets))
             else:
                 d = value.astype(self.output_dtypes[name])


### PR DESCRIPTION
This fixes two issues:
* Adjusts the way the dtypes of `Workflow` output columns get looked up to avoid `KeyError`s when the expected entries aren't in the `output_dtypes` dictionary
* Adjusts the way `Workflow` output columns get turned back into Triton-friendly arrays so that fixed-length list columns are returned as a single multi-dimensional array with no offsets