### PR TITLE
Convert Workflow outputs to Triton-friendly format using `TensorTable`

### DIFF
--- a/merlin/systems/triton/models/workflow_model.py
+++ b/merlin/systems/triton/models/workflow_model.py
@@ -124,6 +124,8 @@ class TritonPythonModel:
 
         # raise pb_utils.TritonModelException("Custom Error To check raised!")
         raw_tensor_tuples = self.runner.run_workflow(input_tensors)
+        if isinstance(raw_tensor_tuples, dict):
+            raw_tensor_tuples = [(name, data) for name, data in raw_tensor_tuples.items()]
 
         result = [pb_utils.Tensor(name, data) for name, data in raw_tensor_tuples]
 

--- a/merlin/systems/triton/models/workflow_model.py
+++ b/merlin/systems/triton/models/workflow_model.py
@@ -125,7 +125,7 @@ class TritonPythonModel:
         # raise pb_utils.TritonModelException("Custom Error To check raised!")
         raw_tensor_tuples = self.runner.run_workflow(input_tensors)
         if isinstance(raw_tensor_tuples, dict):
-            raw_tensor_tuples = [(name, data) for name, data in raw_tensor_tuples.items()]
+            raw_tensor_tuples = list(raw_tensor_tuples.items())
 
         result = [pb_utils.Tensor(name, data) for name, data in raw_tensor_tuples]
 

--- a/merlin/systems/workflow/tensorflow.py
+++ b/merlin/systems/workflow/tensorflow.py
@@ -23,12 +23,9 @@
 # OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-import json
-
-import numpy as np
-
 from merlin.systems.workflow.base import WorkflowRunner
 from merlin.table import TensorTable
+
 
 class TensorflowWorkflowRunner(WorkflowRunner):
     def __init__(self, workflow, output_dtypes, model_config, model_device):

--- a/merlin/systems/workflow/tensorflow.py
+++ b/merlin/systems/workflow/tensorflow.py
@@ -34,6 +34,5 @@ class TensorflowWorkflowRunner(WorkflowRunner):
         self.offsets = None
 
     def _transform_outputs(self, tensors):
-        # Load extra info needed for the Transformer4Rec (if exists)
         output_tensors = TensorTable(tensors).to_dict()
         return output_tensors


### PR DESCRIPTION
Fix some bug related to serving NVT + TensorFlow with Ragged Tensors.

This is an alternative to https://github.com/NVIDIA-Merlin/systems/pull/316