### PR TITLE
Check offsets instead of `is_ragged` for ragged representation

### DIFF
--- a/merlin/systems/triton/conversions.py
+++ b/merlin/systems/triton/conversions.py
@@ -87,7 +87,7 @@ def tensor_table_to_triton_response(tensor_table):
     """
     output_tensors = []
     for name, column in tensor_table.items():
-        if column.is_ragged:
+        if column.offsets is not None:
             values = _triton_tensor_from_array(f"{name}__values", column.values)
             offsets = _triton_tensor_from_array(f"{name}__offsets", column.offsets)
             output_tensors.extend([values, offsets])
@@ -123,7 +123,7 @@ def tensor_table_to_triton_request(model_name, tensor_table, input_col_names, ou
 
     for name, column in tensor_table.items():
         if name in input_col_names:
-            if column.is_ragged:
+            if column.offsets is not None:
                 values = _triton_tensor_from_array(f"{name}__values", column.values)
                 offsets = _triton_tensor_from_array(f"{name}__offsets", column.offsets)
                 input_tensors.extend([values, offsets])


### PR DESCRIPTION
Check `offsets` instead of `is_ragged` for ragged representation. This change is to ensure that when constructing a triton request or response we preserve the ragged representation of the TensorTable 

`is_ragged` currently returns False if there is only one row or the rows happen to have the same length.

This core PR https://github.com/NVIDIA-Merlin/core/pull/273 achieves the same result that this PR does for serving ops with ragged outputs and inputs. However, that one needs further consideration. And checking the offsets explictly here will work whether we make that change to the shape of not.