### PR TITLE
add AUTO kind for deployment of tritonserver and support no gpu environment

### DIFF
--- a/merlin/systems/dag/runtimes/triton/ops/pytorch.py
+++ b/merlin/systems/dag/runtimes/triton/ops/pytorch.py
@@ -162,7 +162,12 @@ class PredictPyTorchTriton(TritonOperator):
         output_path:
             The path to write the exported model to
         """
-        config = model_config.ModelConfig(name=name)
+        config = model_config.ModelConfig(
+            name=name,
+            instance_group=[
+                model_config.ModelInstanceGroup(kind=model_config.ModelInstanceGroup.Kind.KIND_AUTO)
+            ],
+        )
 
         config.backend = "pytorch"
         config.platform = "pytorch_libtorch"

--- a/merlin/systems/dag/runtimes/triton/ops/tensorflow.py
+++ b/merlin/systems/dag/runtimes/triton/ops/tensorflow.py
@@ -126,7 +126,12 @@ class PredictTensorflowTriton(TritonOperator):
             The path to write the exported model to
         """
         config = model_config.ModelConfig(
-            name=name, backend="tensorflow", platform="tensorflow_savedmodel"
+            name=name,
+            backend="tensorflow",
+            platform="tensorflow_savedmodel",
+            instance_group=[
+                model_config.ModelInstanceGroup(kind=model_config.ModelInstanceGroup.Kind.KIND_AUTO)
+            ],
         )
 
         config.parameters["TF_GRAPH_TAG"].string_value = "serve"

--- a/merlin/systems/dag/runtimes/triton/ops/workflow.py
+++ b/merlin/systems/dag/runtimes/triton/ops/workflow.py
@@ -252,7 +252,14 @@ def _generate_nvtabular_config(
 ):
     """given a workflow generates the trton modelconfig proto object describing the inputs
     and outputs to that workflow"""
-    config = model_config.ModelConfig(name=name, backend=backend, max_batch_size=max_batch_size)
+    config = model_config.ModelConfig(
+        name=name,
+        backend=backend,
+        max_batch_size=max_batch_size,
+        instance_group=[
+            model_config.ModelInstanceGroup(kind=model_config.ModelInstanceGroup.Kind.KIND_AUTO)
+        ],
+    )
 
     config.parameters["python_module"].string_value = "merlin.systems.triton.models.workflow_model"
     config.parameters["output_model"].string_value = output_model if output_model else ""

--- a/merlin/systems/dag/runtimes/triton/runtime.py
+++ b/merlin/systems/dag/runtimes/triton/runtime.py
@@ -181,7 +181,12 @@ class TritonExecutorRuntime(Runtime):
         node_export_path.mkdir(parents=True, exist_ok=True)
 
         config = model_config.ModelConfig(
-            name=node_name, backend="python", platform="merlin_executor"
+            name=node_name,
+            backend="python",
+            platform="merlin_executor",
+            instance_group=[
+                model_config.ModelInstanceGroup(kind=model_config.ModelInstanceGroup.Kind.KIND_AUTO)
+            ],
         )
 
         input_schema = ensemble.input_schema

--- a/merlin/systems/triton/conversions.py
+++ b/merlin/systems/triton/conversions.py
@@ -26,15 +26,11 @@
 
 import itertools
 
-try:
-    import cudf
-    import cupy as cp
-except ImportError:
-    cudf = cp = None
-
 import numpy as np
 import pandas as pd
 
+from merlin.core.compat import cudf
+from merlin.core.compat import cupy as cp
 from merlin.core.dispatch import build_cudf_list_column, is_list_dtype
 from merlin.dag import Supports
 from merlin.systems.dag.ops.compat import pb_utils

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,11 +24,10 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from merlin.core.compat import cudf
 from merlin.io import Dataset
 
-try:
-    import cudf
-
+if cudf:
     try:
         import cudf.testing._utils
 
@@ -37,8 +36,7 @@ try:
         import cudf.tests.utils
 
         assert_eq = cudf.tests.utils.assert_eq
-except ImportError:
-    cudf = None
+else:
 
     def assert_eq(a, b, *args, **kwargs):
         if isinstance(a, pd.DataFrame):

--- a/tests/integration/examples/test_serving_an_implicit_model_with_merlin_systems.py
+++ b/tests/integration/examples/test_serving_an_implicit_model_with_merlin_systems.py
@@ -4,17 +4,17 @@ import pytest
 from testbook import testbook
 
 from merlin.systems.triton.utils import run_triton_server
+from merlin.core.compat import cudf
 from tests.conftest import REPO_ROOT
 
 pytest.importorskip("implicit")
 pytest.importorskip("merlin.models")
 
-try:
-    # pylint: disable=unused-import
-    import cudf  # noqa
+
+if cudf:
 
     _TRAIN_ON_GPU = [True, False]
-except ImportError:
+else:
     _TRAIN_ON_GPU = [False]
 
 TRITON_SERVER_PATH = shutil.which("tritonserver")

--- a/tests/unit/systems/dag/runtimes/local/ops/fil/test_xgboost.py
+++ b/tests/unit/systems/dag/runtimes/local/ops/fil/test_xgboost.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from merlin.core.compat import HAS_GPU
 from merlin.dag import ColumnSelector
 from merlin.dtypes.shape import Shape
 from merlin.schema import ColumnSchema, Schema
@@ -16,6 +17,7 @@ export = pytest.importorskip("merlin.systems.dag.ensemble")
 
 
 @pytest.mark.parametrize("runtime", [Runtime()])
+@pytest.mark.skipif(not HAS_GPU, reason="no gpu detected")
 def test_xgboost_regressor_forest_inference(runtime, tmpdir):
     rows = 200
     num_features = 16
@@ -50,6 +52,7 @@ def test_xgboost_regressor_forest_inference(runtime, tmpdir):
     assert response["output__0"].shape == Shape((5,))
 
 
+@pytest.mark.skipif(not HAS_GPU, reason="no gpu detected")
 @pytest.mark.parametrize("runtime", [Runtime()])
 def test_xgboost_classify_forest_inference(runtime, tmpdir):
     rows = 200

--- a/tests/unit/systems/dag/runtimes/triton/ops/fil/test_xgboost_triton.py
+++ b/tests/unit/systems/dag/runtimes/triton/ops/fil/test_xgboost_triton.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from merlin.core.compat import HAS_GPU
 from merlin.dag import ColumnSelector
 from merlin.schema import ColumnSchema, Schema
 from merlin.systems.dag.ensemble import Ensemble
@@ -26,6 +27,7 @@ TRITON_SERVER_PATH = shutil.which("tritonserver")
         (TritonExecutorRuntime(), None, "executor_model"),
     ],
 )
+@pytest.mark.skipif(not HAS_GPU, reason="no gpu detected")
 def test_xgboost_regressor_forest_inference(runtime, model_name, expected_model_name, tmpdir):
     rows = 200
     num_features = 16
@@ -64,6 +66,7 @@ def test_xgboost_regressor_forest_inference(runtime, model_name, expected_model_
 
 
 @pytest.mark.skipif(not TRITON_SERVER_PATH, reason="triton server not found")
+@pytest.mark.skipif(not HAS_GPU, reason="no gpu detected")
 @pytest.mark.parametrize(
     ["runtime", "model_name", "expected_model_name"],
     [

--- a/tests/unit/systems/ops/fil/test_ensemble.py
+++ b/tests/unit/systems/ops/fil/test_ensemble.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import shutil
 
 import numpy as np
@@ -22,14 +21,13 @@ import pytest
 import sklearn.datasets
 import xgboost
 
-os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
-
-from merlin.dag import ColumnSelector  # noqa
-from merlin.io import Dataset  # noqa
-from merlin.schema import ColumnSchema, Schema  # noqa
-from merlin.systems.dag.ops.fil import PredictForest  # noqa
-from nvtabular import Workflow  # noqa
-from nvtabular import ops as wf_ops  # noqa
+from merlin.core.compat import HAS_GPU
+from merlin.dag import ColumnSelector
+from merlin.io import Dataset
+from merlin.schema import ColumnSchema, Schema
+from merlin.systems.dag.ops.fil import PredictForest
+from nvtabular import Workflow
+from nvtabular import ops as wf_ops
 
 triton = pytest.importorskip("merlin.systems.triton")
 export = pytest.importorskip("merlin.systems.dag.ensemble")
@@ -42,6 +40,7 @@ TRITON_SERVER_PATH = shutil.which("tritonserver")
 
 
 @pytest.mark.skipif(not TRITON_SERVER_PATH, reason="triton server not found")
+@pytest.mark.skipif(not HAS_GPU, reason="no gpu detected")
 def test_workflow_with_forest_inference(tmpdir):
     rows = 200
     num_features = 16

--- a/tests/unit/systems/ops/fil/test_forest.py
+++ b/tests/unit/systems/ops/fil/test_forest.py
@@ -22,6 +22,7 @@ import xgboost
 from google.protobuf import text_format
 from tritonclient.grpc import model_config_pb2 as model_config
 
+from merlin.core.compat import HAS_GPU
 from merlin.core.utils import Distributed
 from merlin.dag import ColumnSelector
 from merlin.io import Dataset
@@ -41,6 +42,7 @@ def read_config(config_path):
         return text_format.Parse(raw_config, config)
 
 
+@pytest.mark.skipif(not HAS_GPU, reason="no gpu detected")
 def test_export(tmpdir):
     rows = 200
     num_features = 16
@@ -65,6 +67,7 @@ def test_export(tmpdir):
     assert parsed_config.backend == "fil"
 
 
+@pytest.mark.skipif(not HAS_GPU, reason="no gpu detected")
 def test_export_merlin_models(tmpdir):
     merlin_xgb = pytest.importorskip("merlin.models.xgb")
 
@@ -101,6 +104,7 @@ def test_export_merlin_models(tmpdir):
     assert parsed_config.backend == "fil"
 
 
+@pytest.mark.skipif(not HAS_GPU, reason="no gpu detected")
 def test_ensemble(tmpdir):
     rows = 200
     num_features = 16


### PR DESCRIPTION
This PR ensures that all model configs for triton are setup to handle any environment, removing the need to recreate the model config depending on the hardware environment (i.e. CPU/GPU) we need this because without these changes our current model configs are setup to only handle GPU environments. When you run those model configs outside of a GPU environment you get errors from triton because of it. We also added guards for certain tests that cannot run without a GPU available (i.e. xgboost). And we are importing GPU specific libraries using the core compat imports to ensure we are using them correctly.