### PR TITLE
Support Ragged inputs and outputs in `TransformWorkflow` with Triton

### DIFF
--- a/merlin/systems/triton/export.py
+++ b/merlin/systems/triton/export.py
@@ -31,12 +31,12 @@ def _add_model_param(col_schema, paramclass, params, dims=None):
             paramclass(
                 name=col_schema.name + "__values",
                 data_type=_convert_dtype(col_schema.dtype),
-                dims=dims,
+                dims=[-1],
             )
         )
         params.append(
             paramclass(
-                name=col_schema.name + "__offsets", data_type=model_config.TYPE_INT32, dims=dims
+                name=col_schema.name + "__offsets", data_type=model_config.TYPE_INT32, dims=[-1]
             )
         )
     else:

--- a/merlin/systems/workflow/base.py
+++ b/merlin/systems/workflow/base.py
@@ -29,6 +29,8 @@ import itertools
 import json
 import logging
 
+import numpy as np
+
 from merlin.core.compat import cupy
 from merlin.core.dispatch import concat_columns
 from merlin.dag import ColumnSelector, Supports

--- a/merlin/systems/workflow/base.py
+++ b/merlin/systems/workflow/base.py
@@ -114,14 +114,14 @@ class WorkflowRunner:
         for col in self.workflow.output_schema:
             if col.is_ragged and output_table[col.name].offsets is None:
                 values, offsets = _to_ragged(output_table[col.name].values)
-                values = values.astype(self.output_dtypes[col.name + "__values"])
-                offsets = offsets.astype(self.output_dtypes[col.name + "__offsets"])
                 output_table[col.name] = TensorColumn(values, offsets=offsets)
-            else:
-                values = output_table[col.name].values.astype(self.output_dtypes[col.name])
-                output_table[col.name] = TensorColumn(values)
 
-        return output_table.to_dict()
+        output_dict = output_table.to_dict()
+
+        for key, value in output_dict.items():
+            output_dict[key] = value.astype(self.output_dtypes[key])
+
+        return output_dict
 
     def _transform_tensors(self, input_tensors, workflow_node):
         upstream_inputs = []

--- a/merlin/systems/workflow/base.py
+++ b/merlin/systems/workflow/base.py
@@ -117,6 +117,9 @@ class WorkflowRunner:
                 values = values.astype(self.output_dtypes[col.name + "__values"])
                 offsets = offsets.astype(self.output_dtypes[col.name + "__offsets"])
                 output_table[col.name] = TensorColumn(values, offsets=offsets)
+            else:
+                values = output_table[col.name].values.astype(self.output_dtypes[col.name])
+                output_table[col.name] = TensorColumn(values)
 
         return output_table.to_dict()
 

--- a/merlin/systems/workflow/base.py
+++ b/merlin/systems/workflow/base.py
@@ -29,12 +29,12 @@ import itertools
 import json
 import logging
 
-from merlin.core.dispatch import concat_columns
 from merlin.core.compat import cupy
+from merlin.core.dispatch import concat_columns
 from merlin.dag import ColumnSelector, Supports
 from merlin.schema import Tags
 from merlin.systems.triton.conversions import convert_format
-from merlin.table import TensorTable, TensorColumn
+from merlin.table import TensorColumn, TensorTable
 
 LOG = logging.getLogger("merlin-systems")
 

--- a/tests/unit/systems/dag/runtimes/triton/ops/workflow/test_ensemble.py
+++ b/tests/unit/systems/dag/runtimes/triton/ops/workflow/test_ensemble.py
@@ -194,13 +194,13 @@ def test_workflow_with_ragged_output(tmpdir):
                 for key, value in expected_response.items():
                     np.testing.assert_array_equal(response[key], value)
 
+
 @pytest.mark.skipif(not TRITON_SERVER_PATH, reason="triton server not found")
 def test_workflow_with_padded_output(tmpdir):
     df = make_df({"x": [100, 200, 300], "session_id": [1, 1, 2]})
     dataset = Dataset(df)
-    workflow_ops = (
-        ["x", "session_id"]
-        >> wf_ops.Groupby(groupby_cols=["session_id"], aggs={"x": ["list"]}, name_sep="-")
+    workflow_ops = ["x", "session_id"] >> wf_ops.Groupby(
+        groupby_cols=["session_id"], aggs={"x": ["list"]}, name_sep="-"
     )
     workflow_ops = workflow_ops["x-list"] >> wf_ops.ListSlice(-3, pad=True)
     workflow = Workflow(workflow_ops)
@@ -245,7 +245,7 @@ def test_workflow_with_padded_output(tmpdir):
                     schema, df, output_names, client=client, triton_model=model_name
                 )
                 for key, value in expected_response.items():
-                    np.testing.assert_array_equal(response[key], value)                    
+                    np.testing.assert_array_equal(response[key], value)
 
 
 @pytest.mark.skipif(not TRITON_SERVER_PATH, reason="triton server not found")


### PR DESCRIPTION
Part of #322 and #135
Replaces #316 

Updates `TransformWorkflow` Triton workflow model to handle NVTabular workflows that have ragged inputs or outputs.

Adds tests for the `TransformWorkflow` usage with ragged inputs and outputs and padded outputs.

