### PR TITLE
use concurrency setting to kill already-running jobs when new commits come in

### DIFF
--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -6,6 +6,10 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cpu-ci-premerge:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -6,6 +6,10 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gpu-ci-premerge:
     runs-on: 1GPU


### PR DESCRIPTION
This should help relieve the stress on our CI runners (and also on github's, for the cpu tests).

If this works well, we can put it in all of the other workflows.