### PR TITLE
Refactor tensor representation adjustments to align with a schema

### DIFF
--- a/merlin/systems/dag/runtimes/triton/ops/fil.py
+++ b/merlin/systems/dag/runtimes/triton/ops/fil.py
@@ -145,12 +145,14 @@ class PredictForestTriton(TritonOperator):
         )
 
         inputs = TensorTable({"input__0": input0})
+        input_schema = Schema(["input__0"])
+        output_schema = Schema(["output__0"])
 
         inference_request = tensor_table_to_triton_request(
-            self.fil_model_name, inputs, ["input__0"], ["output__0"]
+            self.fil_model_name, inputs, input_schema, output_schema
         )
         inference_response = inference_request.exec()
-        return triton_response_to_tensor_table(inference_response, type(inputs), ["output__0"])
+        return triton_response_to_tensor_table(inference_response, type(inputs), output_schema)
 
 
 class FILTriton(TritonOperator):

--- a/merlin/systems/dag/runtimes/triton/ops/pytorch.py
+++ b/merlin/systems/dag/runtimes/triton/ops/pytorch.py
@@ -77,14 +77,14 @@ class PredictPyTorchTriton(TritonOperator):
         inference_request = tensor_table_to_triton_request(
             self.torch_model_name,
             transformable,
-            self.input_schema.column_names,
-            self.output_schema.column_names,
+            self.input_schema,
+            self.output_schema,
         )
 
         inference_response = inference_request.exec()
 
         return triton_response_to_tensor_table(
-            inference_response, type(transformable), self.output_schema.column_names
+            inference_response, type(transformable), self.output_schema
         )
 
     def compute_input_schema(

--- a/merlin/systems/dag/runtimes/triton/ops/tensorflow.py
+++ b/merlin/systems/dag/runtimes/triton/ops/tensorflow.py
@@ -71,14 +71,14 @@ class PredictTensorflowTriton(TritonOperator):
         inference_request = tensor_table_to_triton_request(
             self.tf_model_name,
             transformable,
-            self.input_schema.column_names,
-            self.output_schema.column_names,
+            self.input_schema,
+            self.output_schema,
         )
         inference_response = inference_request.exec()
 
         # TODO: Validate that the outputs match the schema
         return triton_response_to_tensor_table(
-            inference_response, type(transformable), self.output_schema.column_names
+            inference_response, type(transformable), self.output_schema
         )
 
     def export(

--- a/merlin/systems/dag/runtimes/triton/ops/workflow.py
+++ b/merlin/systems/dag/runtimes/triton/ops/workflow.py
@@ -80,19 +80,11 @@ class TransformWorkflowTriton(TritonOperator):
         TensorTable
             Returns a transformed dataframe for this operator"""
 
-        output_names = []
-        for col in self.output_schema:
-            if col.is_ragged:
-                output_names.append(f"{col.name}__values")
-                output_names.append(f"{col.name}__offsets")
-            else:
-                output_names.append(col.name)
-
         inference_request = tensor_table_to_triton_request(
             self._nvt_model_name,
             transformable,
-            self.input_schema.column_names,
-            output_names,
+            self.input_schema,
+            self.output_schema,
         )
 
         inference_response = inference_request.exec()
@@ -105,7 +97,7 @@ class TransformWorkflowTriton(TritonOperator):
             )
 
         response_table = triton_response_to_tensor_table(
-            inference_response, type(transformable), output_names
+            inference_response, type(transformable), self.output_schema
         )
 
         return response_table

--- a/merlin/systems/triton/models/executor_model.py
+++ b/merlin/systems/triton/models/executor_model.py
@@ -92,9 +92,9 @@ class TritonPythonModel:
           A list of pb_utils.InferenceResponse. The length of this list must
           be the same as `requests`
         """
-        inputs = triton_request_to_tensor_table(request, self.ensemble.input_schema.column_names)
+        inputs = triton_request_to_tensor_table(request, self.ensemble.input_schema)
         outputs = self.ensemble.transform(inputs, runtime=TritonExecutorRuntime())
-        return tensor_table_to_triton_response(outputs)
+        return tensor_table_to_triton_response(outputs, self.ensemble.output_schema)
 
 
 def _parse_model_repository(model_repository: str) -> str:

--- a/merlin/systems/workflow/base.py
+++ b/merlin/systems/workflow/base.py
@@ -31,7 +31,7 @@ import logging
 from merlin.core.dispatch import concat_columns
 from merlin.dag import ColumnSelector, Supports
 from merlin.schema import Tags
-from merlin.systems.triton.conversions import align_with_schema, convert_format
+from merlin.systems.triton.conversions import convert_format, match_representations
 from merlin.table import TensorTable
 
 LOG = logging.getLogger("merlin-systems")
@@ -106,7 +106,7 @@ class WorkflowRunner:
             transformed, kind = convert_format(transformed, kind, Supports.CPU_DICT_ARRAY)
 
         transformed = TensorTable(transformed).to_dict()
-        output_dict = align_with_schema(self.workflow.output_schema, transformed)
+        output_dict = match_representations(self.workflow.output_schema, transformed)
 
         for key, value in output_dict.items():
             output_dict[key] = value.astype(self.output_dtypes[key])


### PR DESCRIPTION
This PR creates some helper methods for doing the conversion of values-only columns to the values/offsets representation when indicated by the schema of whatever comes next (e.g. returning columns in the flat dictionary format used by Triton responses.)