### PR TITLE
Raise TritonModelException if the Triton model has an error

### DIFF
--- a/merlin/systems/dag/runtimes/triton/ops/fil.py
+++ b/merlin/systems/dag/runtimes/triton/ops/fil.py
@@ -159,7 +159,6 @@ class PredictForestTriton(TritonOperator):
         return triton_response_to_tensor_table(inference_response, type(inputs), output_schema)
 
 
-
 class FILTriton(TritonOperator):
     """Operator for Forest Inference Library (FIL) models.
 

--- a/merlin/systems/dag/runtimes/triton/ops/fil.py
+++ b/merlin/systems/dag/runtimes/triton/ops/fil.py
@@ -150,6 +150,10 @@ class PredictForestTriton(TritonOperator):
             self.fil_model_name, inputs, ["input__0"], ["output__0"]
         )
         inference_response = inference_request.exec()
+
+        if inference_response.has_error():
+            raise RuntimeError(str(inference_response.error().message()))
+
         return triton_response_to_tensor_table(inference_response, type(inputs), ["output__0"])
 
 

--- a/merlin/systems/dag/runtimes/triton/ops/pytorch.py
+++ b/merlin/systems/dag/runtimes/triton/ops/pytorch.py
@@ -83,6 +83,9 @@ class PredictPyTorchTriton(TritonOperator):
 
         inference_response = inference_request.exec()
 
+        if inference_response.has_error():
+            raise RuntimeError(inference_response.error().message())
+
         return triton_response_to_tensor_table(
             inference_response, type(transformable), self.output_schema.column_names
         )

--- a/merlin/systems/dag/runtimes/triton/ops/pytorch.py
+++ b/merlin/systems/dag/runtimes/triton/ops/pytorch.py
@@ -84,7 +84,7 @@ class PredictPyTorchTriton(TritonOperator):
         inference_response = inference_request.exec()
 
         if inference_response.has_error():
-            raise RuntimeError(inference_response.error().message())
+            raise RuntimeError(str(inference_response.error().message()))
 
         return triton_response_to_tensor_table(
             inference_response, type(transformable), self.output_schema.column_names

--- a/merlin/systems/dag/runtimes/triton/ops/tensorflow.py
+++ b/merlin/systems/dag/runtimes/triton/ops/tensorflow.py
@@ -76,6 +76,9 @@ class PredictTensorflowTriton(TritonOperator):
         )
         inference_response = inference_request.exec()
 
+        if inference_response.has_error():
+            raise RuntimeError(inference_response.error().message())
+
         # TODO: Validate that the outputs match the schema
         return triton_response_to_tensor_table(
             inference_response, type(transformable), self.output_schema.column_names

--- a/merlin/systems/dag/runtimes/triton/ops/workflow.py
+++ b/merlin/systems/dag/runtimes/triton/ops/workflow.py
@@ -20,7 +20,6 @@ import pathlib
 from shutil import copyfile
 
 import tritonclient.grpc.model_config_pb2 as model_config
-import tritonclient.utils
 from google.protobuf import text_format
 
 from merlin.core.protocols import Transformable
@@ -97,12 +96,8 @@ class TransformWorkflowTriton(TritonOperator):
 
         inference_response = inference_request.exec()
 
-        # check inference response for errors:
         if inference_response.has_error():
-            # Cannot raise inference response error because it is not derived from BaseException
-            raise tritonclient.utils.InferenceServerException(
-                str(inference_response.error().message())
-            )
+            raise RuntimeError(inference_response.error().message())
 
         response_table = triton_response_to_tensor_table(
             inference_response, type(transformable), output_names

--- a/merlin/systems/triton/models/executor_model.py
+++ b/merlin/systems/triton/models/executor_model.py
@@ -26,6 +26,8 @@
 import pathlib
 from pathlib import Path
 
+import triton_python_backend_utils as pb_utils
+
 from merlin.dag import postorder_iter_nodes
 from merlin.systems.dag import Ensemble
 from merlin.systems.dag.runtimes.triton import TritonExecutorRuntime
@@ -93,7 +95,10 @@ class TritonPythonModel:
           be the same as `requests`
         """
         inputs = triton_request_to_tensor_table(request, self.ensemble.input_schema.column_names)
-        outputs = self.ensemble.transform(inputs, runtime=TritonExecutorRuntime())
+        try:
+            outputs = self.ensemble.transform(inputs, runtime=TritonExecutorRuntime())
+        except Exception as exc:
+            raise pb_utils.TritonModelException(str(exc))
         return tensor_table_to_triton_response(outputs)
 
 

--- a/merlin/systems/triton/models/executor_model.py
+++ b/merlin/systems/triton/models/executor_model.py
@@ -101,6 +101,7 @@ class TritonPythonModel:
             raise pb_utils.TritonModelException(str(exc)) from exc
         return tensor_table_to_triton_response(outputs, self.ensemble.output_schema)
 
+
 def _parse_model_repository(model_repository: str) -> str:
     """
     Extract the model repository path from the model_repository value

--- a/merlin/systems/triton/models/executor_model.py
+++ b/merlin/systems/triton/models/executor_model.py
@@ -98,7 +98,7 @@ class TritonPythonModel:
         try:
             outputs = self.ensemble.transform(inputs, runtime=TritonExecutorRuntime())
         except Exception as exc:
-            raise pb_utils.TritonModelException(str(exc))
+            raise pb_utils.TritonModelException(str(exc)) from exc
         return tensor_table_to_triton_response(outputs)
 
 

--- a/tests/unit/systems/ops/torch/test_ensemble.py
+++ b/tests/unit/systems/ops/torch/test_ensemble.py
@@ -1,0 +1,97 @@
+#
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import shutil
+
+import numpy as np
+import pandas as pd
+import pytest
+import tritonclient.utils
+
+from merlin.schema import ColumnSchema, Schema
+from merlin.systems.dag.ensemble import Ensemble
+from merlin.systems.dag.ops.pytorch import PredictPyTorch
+from merlin.systems.triton.utils import run_ensemble_on_tritonserver
+
+torch = pytest.importorskip("torch")
+
+TRITON_SERVER_PATH = shutil.which("tritonserver")
+
+
+@pytest.mark.skipif(not TRITON_SERVER_PATH, reason="triton server not found")
+def test_model_in_ensemble(tmpdir):
+    class MyModel(torch.nn.Module):
+        def forward(self, x):
+            v = torch.stack(list(x.values())).sum(axis=0)
+            return v
+
+    model = MyModel()
+
+    traced_model = torch.jit.trace(model, {"a": torch.tensor(1), "b": torch.tensor(2)}, strict=True)
+
+    model_input_schema = Schema(
+        [ColumnSchema("a", dtype="int64"), ColumnSchema("b", dtype="int64")]
+    )
+    model_output_schema = Schema([ColumnSchema("output", dtype="int64")])
+
+    model_node = model_input_schema.column_names >> PredictPyTorch(
+        traced_model, model_input_schema, model_output_schema
+    )
+
+    ensemble = Ensemble(model_node, model_input_schema)
+
+    ensemble_config, _ = ensemble.export(str(tmpdir))
+
+    df = pd.DataFrame({"a": [1], "b": [2]})
+
+    response = run_ensemble_on_tritonserver(
+        str(tmpdir), model_input_schema, df, ["output"], ensemble_config.name
+    )
+    np.testing.assert_array_equal(response["output"], np.array([3]))
+
+
+@pytest.mark.skipif(not TRITON_SERVER_PATH, reason="triton server not found")
+def test_model_error(tmpdir):
+    class MyModel(torch.nn.Module):
+        def forward(self, x):
+            v = torch.stack(list(x.values())).sum()
+            return v
+
+    model = MyModel()
+
+    traced_model = torch.jit.trace(model, {"a": torch.tensor(1), "b": torch.tensor(2)}, strict=True)
+
+    model_input_schema = Schema([ColumnSchema("a", dtype="int64")])
+    model_output_schema = Schema([ColumnSchema("output", dtype="int64")])
+
+    model_node = model_input_schema.column_names >> PredictPyTorch(
+        traced_model, model_input_schema, model_output_schema
+    )
+
+    ensemble = Ensemble(model_node, model_input_schema)
+
+    ensemble_config, _ = ensemble.export(str(tmpdir))
+
+    # run inference with missing input (that was present when model was compiled)
+    # we're expecting a KeyError at runtime.
+    df = pd.DataFrame({"a": [1]})
+
+    with pytest.raises(tritonclient.utils.InferenceServerException) as exc_info:
+        run_ensemble_on_tritonserver(
+            str(tmpdir), model_input_schema, df, ["output"], ensemble_config.name
+        )
+    assert "The following operation failed in the TorchScript interpreter" in str(exc_info.value)
+    assert "RuntimeError: KeyError: b" in str(exc_info.value)


### PR DESCRIPTION
Raises error from `PredictPyTorchTriton` and in the executor model so that any errors in the pytorch model are surfaced.

Currently might see a cryptic error about missing keys in a response, while the actual error that happened in one of the backends (e.g. pytorch) doesn't get reported or printed anywhere.

## Example

Using the test added in this PR as an example `tests/unit/systems/ops/torch/test_ensemble.py::test_model_error`

### Before

```
Failed to transform operator <merlin.systems.dag.runtimes.triton.ops.pytorch.PredictPyTorchTriton object at 0x7f017f6129d0>
Traceback (most recent call last):
  File "/workspace/merlin/systems/merlin/systems/triton/conversions.py", line 160, in triton_response_to_tensor_table
    values = _array_from_triton_tensor(response, f"{out_col_name}__values")
  File "/workspace/merlin/systems/merlin/systems/triton/conversions.py", line 197, in _array_from_triton_tensor
    raise ValueError(f"Column {name} not found in {type(triton_obj)}")
ValueError: Column output__values not found in <class 'c_python_backend_utils.InferenceResponse'>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 175, in _run_node_transform
    transformed_data = node.op.transform(selection, input_data)
  File "/workspace/merlin/systems/merlin/systems/dag/runtimes/triton/ops/pytorch.py", line 89, in transform
    return triton_response_to_tensor_table(
  File "/workspace/merlin/systems/merlin/systems/triton/conversions.py", line 164, in triton_response_to_tensor_table
    outputs_dict[out_col_name] = _array_from_triton_tensor(response, out_col_name)
  File "/workspace/merlin/systems/merlin/systems/triton/conversions.py", line 197, in _array_from_triton_tensor
    raise ValueError(f"Column {name} not found in {type(triton_obj)}")
ValueError: Column output not found in <class 'c_python_backend_utils.InferenceResponse'>
```

### After

```
Failed to transform operator <merlin.systems.dag.runtimes.triton.ops.pytorch.PredictPyTorchTriton object at 0x7fa4860699d0>
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 175, in _run_node_transform
    transformed_data = node.op.transform(selection, input_data)
  File "/workspace/merlin/systems/merlin/systems/dag/runtimes/triton/ops/pytorch.py", line 87, in transform
    raise RuntimeError(str(inference_response.error().message()))
RuntimeError: PyTorch execute failure: The following operation failed in the TorchScript interpreter.
Traceback of TorchScript, serialized code (most recent call last):
  File "code/__torch__/tests/unit/systems/ops/torch/test_ensemble.py", line 8, in forward
  def forward(self: __torch__.tests.unit.systems.ops.torch.test_ensemble.MyModel,
    x: Dict[str, Tensor]) -> Tensor:
    _0 = torch.sum(torch.stack([x["a"], x["b"]]))
                                        ~~~~~~ <--- HERE
    return _0

Traceback of TorchScript, original code (most recent call last):
/usr/local/lib/python3.8/dist-packages/torch/jit/_trace.py(967): trace_module
/usr/local/lib/python3.8/dist-packages/torch/jit/_trace.py(750): trace
/workspace/merlin/systems/tests/unit/systems/ops/torch/test_ensemble.py(75): test_model_error
/usr/local/lib/python3.8/dist-packages/_pytest/python.py(192): pytest_pyfunc_call
/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py(39): _multicall
/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py(80): _hookexec
/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py(265): __call__
/usr/local/lib/python3.8/dist-packages/_pytest/python.py(1761): runtest
/usr/local/lib/python3.8/dist-packages/_pytest/runner.py(166): pytest_runtest_call
/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py(39): _multicall
/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py(80): _hookexec
/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py(265): __call__
/usr/local/lib/python3.8/dist-packages/_pytest/runner.py(259): <lambda>
/usr/local/lib/python3.8/dist-packages/_pytest/runner.py(338): from_call
/usr/local/lib/python3.8/dist-packages/_pytest/runner.py(258): call_runtest_hook
/usr/local/lib/python3.8/dist-packages/_pytest/runner.py(219): call_and_report
/usr/local/lib/python3.8/dist-packages/_pytest/runner.py(130): runtestprotocol
/usr/local/lib/python3.8/dist-packages/_pytest/runner.py(111): pytest_runtest_protocol
/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py(39): _multicall
/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py(80): _hookexec
/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py(265): __call__
/usr/local/lib/python3.8/dist-packages/_pytest/main.py(347): pytest_runtestloop
/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py(39): _multicall
/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py(80): _hookexec
/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py(265): __call__
/usr/local/lib/python3.8/dist-packages/_pytest/main.py(322): _main
/usr/local/lib/python3.8/dist-packages/_pytest/main.py(268): wrap_session
/usr/local/lib/python3.8/dist-packages/_pytest/main.py(315): pytest_cmdline_main
/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py(39): _multicall
/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py(80): _hookexec
/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py(265): __call__
/usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py(164): main
/usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py(187): console_main
/usr/local/lib/python3.8/dist-packages/pytest/__main__.py(5): <module>
/usr/lib/python3.8/runpy.py(87): _run_code
/usr/lib/python3.8/runpy.py(87): _run_code
/usr/lib/python3.8/runpy.py(194): _run_module_as_main
RuntimeError: KeyError: b
```