### PR TITLE
Update requirements for Merlin packages to minimum version of 23.04 

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,3 +4,5 @@ requests>=2.10,<3
 # regardless of whether in GPU/CPU environment must support sklearn which is CPU only.
 treelite==2.4.0
 treelite_runtime==2.4.0
+
+tritonclient[all]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
-merlin-core>=0.2.0
-nvtabular>=1.0.0
+merlin-core>=23.4.0
+nvtabular>=23.4.0
 requests>=2.10,<3
 # regardless of whether in GPU/CPU environment must support sklearn which is CPU only.
 treelite==2.4.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,6 @@
 -r base.txt
 -r dev.txt
 
-tritonclient[all]
 tensorflow<=2.9.0
 
 Sphinx==3.5.4

--- a/requirements/test-cpu.txt
+++ b/requirements/test-cpu.txt
@@ -1,6 +1,6 @@
 -r test.txt
 
-merlin-models>=0.6.0
+merlin-models>=23.4.0
 faiss-cpu==1.7.2
 tensorflow<=2.9.0
 treelite==2.4.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,7 +13,6 @@ asvdb@git+https://github.com/rapidsai/asvdb.git
 testbook==0.4.2
 
 # packages necessary to run tests and push PRs
-tritonclient
 feast==0.19.4
 xgboost==1.6.2
 implicit==0.6.0


### PR DESCRIPTION
Update requirements for Merlin Core package to minimum version of 23.04. This contains features required for the upcoming release. Also moves `tritonclient` to the base requirements.

Depends on merlin-core 23.4.0 package publish.