### PR TITLE
Update feast test dependency from 0.19.4 to 0.18.1

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,7 @@ testbook==0.4.2
 
 # packages necessary to run tests and push PRs
 tritonclient
-feast==0.19.4
+feast==0.18.1
 xgboost==1.6.2
 implicit==0.6.0
 


### PR DESCRIPTION
Update feast test dependency from 0.19.4 to 0.18.1

This version doesn't have a dependency on dask and avoids the dask version conflict with merlin-core