### PR TITLE
Update `test_export_merlin_models` test to run on dynamic dask cluster type

### DIFF
--- a/tests/unit/systems/ops/fil/test_forest.py
+++ b/tests/unit/systems/ops/fil/test_forest.py
@@ -87,7 +87,7 @@ def test_export_merlin_models(tmpdir):
 
     # train a XGB model using merlin-models
     model = merlin_xgb.XGBoost(ds.schema)
-    with Distributed(cluster_type="cpu"):
+    with Distributed():
         model.fit(ds)
 
     # make sure we can export the merlin-model xgb wrapper using merlin-systems


### PR DESCRIPTION
- remove `cluster_type="cpu"` from `test_export_merlin_models`
   - this fixes issue we're seeing with dask unmanaged memory errors in our CI builds
   - This issue occurs when in a GPU environment, the `merlin.io.Dataset` by default constructs a dask_cudf dataframe if a GPU is available, and when running this on a dask CPU cluster, we get unmanaged memory errors. Ideally if this is a known compatibility issue, it would be preferable to get a RuntimeError or similar indicating that when using a dask CPU based LocalCluster, a regular dask dataframe should be used intead.

