### PR TITLE
Update FIL tests to run on CPU as well as GPU

### DIFF
--- a/tests/unit/systems/dag/runtimes/triton/ops/fil/test_xgboost_triton.py
+++ b/tests/unit/systems/dag/runtimes/triton/ops/fil/test_xgboost_triton.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from merlin.core.compat import HAS_GPU
 from merlin.dag import ColumnSelector
 from merlin.schema import ColumnSchema, Schema
 from merlin.systems.dag.ensemble import Ensemble
@@ -27,7 +26,6 @@ TRITON_SERVER_PATH = shutil.which("tritonserver")
         (TritonExecutorRuntime(), None, "executor_model"),
     ],
 )
-@pytest.mark.skipif(not HAS_GPU, reason="no gpu detected")
 def test_xgboost_regressor_forest_inference(runtime, model_name, expected_model_name, tmpdir):
     rows = 200
     num_features = 16
@@ -66,7 +64,6 @@ def test_xgboost_regressor_forest_inference(runtime, model_name, expected_model_
 
 
 @pytest.mark.skipif(not TRITON_SERVER_PATH, reason="triton server not found")
-@pytest.mark.skipif(not HAS_GPU, reason="no gpu detected")
 @pytest.mark.parametrize(
     ["runtime", "model_name", "expected_model_name"],
     [

--- a/tests/unit/systems/ops/fil/test_ensemble.py
+++ b/tests/unit/systems/ops/fil/test_ensemble.py
@@ -21,7 +21,6 @@ import pytest
 import sklearn.datasets
 import xgboost
 
-from merlin.core.compat import HAS_GPU
 from merlin.dag import ColumnSelector
 from merlin.io import Dataset
 from merlin.schema import ColumnSchema, Schema
@@ -40,7 +39,6 @@ TRITON_SERVER_PATH = shutil.which("tritonserver")
 
 
 @pytest.mark.skipif(not TRITON_SERVER_PATH, reason="triton server not found")
-@pytest.mark.skipif(not HAS_GPU, reason="no gpu detected")
 def test_workflow_with_forest_inference(tmpdir):
     rows = 200
     num_features = 16

--- a/tests/unit/systems/ops/fil/test_forest.py
+++ b/tests/unit/systems/ops/fil/test_forest.py
@@ -22,7 +22,6 @@ import xgboost
 from google.protobuf import text_format
 from tritonclient.grpc import model_config_pb2 as model_config
 
-from merlin.core.compat import HAS_GPU
 from merlin.core.utils import Distributed
 from merlin.dag import ColumnSelector
 from merlin.io import Dataset
@@ -42,7 +41,6 @@ def read_config(config_path):
         return text_format.Parse(raw_config, config)
 
 
-@pytest.mark.skipif(not HAS_GPU, reason="no gpu detected")
 def test_export(tmpdir):
     rows = 200
     num_features = 16
@@ -67,7 +65,6 @@ def test_export(tmpdir):
     assert parsed_config.backend == "fil"
 
 
-@pytest.mark.skipif(not HAS_GPU, reason="no gpu detected")
 def test_export_merlin_models(tmpdir):
     merlin_xgb = pytest.importorskip("merlin.models.xgb")
 
@@ -104,7 +101,6 @@ def test_export_merlin_models(tmpdir):
     assert parsed_config.backend == "fil"
 
 
-@pytest.mark.skipif(not HAS_GPU, reason="no gpu detected")
 def test_ensemble(tmpdir):
     rows = 200
     num_features = 16

--- a/tests/unit/systems/ops/fil/test_op.py
+++ b/tests/unit/systems/ops/fil/test_op.py
@@ -25,12 +25,9 @@ from google.protobuf import text_format  # noqa
 from tritonclient.grpc import model_config_pb2 as model_config  # noqa
 
 import merlin.systems.dag.ops.fil as fil_op
-from merlin.core.compat import HAS_GPU
 from merlin.dag import ColumnSelector, Graph
 from merlin.schema import Schema
 from merlin.systems.dag.runtimes.triton.ops.fil import FILTriton
-
-need_gpu = pytest.mark.skipif(not HAS_GPU, reason="No GPU available")
 
 
 def export_op(export_dir, triton_op) -> model_config.ModelConfig:
@@ -150,7 +147,6 @@ def test_binary_classifier_default_cpu(get_model_fn, get_model_params, tmpdir):
     ["get_model_fn", "get_model_params"],
     [(xgboost_train, {"objective": "binary:logistic"}), (xgboost_classifier, {})],
 )
-@need_gpu
 def test_binary_classifier_default_gpu(get_model_fn, get_model_params, tmpdir):
     X, y = get_classification_data(classes=2)
     model = get_model_fn(X, y, **get_model_params)
@@ -165,7 +161,6 @@ def test_binary_classifier_default_gpu(get_model_fn, get_model_params, tmpdir):
     ["get_model_fn", "get_model_params"],
     [(xgboost_train, {"objective": "binary:logistic"}), (xgboost_classifier, {})],
 )
-@need_gpu
 def test_binary_classifier_with_proba_gpu(get_model_fn, get_model_params, tmpdir):
     X, y = get_classification_data(classes=2)
     model = get_model_fn(X, y, **get_model_params)
@@ -198,7 +193,6 @@ def test_binary_classifier_with_proba_cpu(get_model_fn, get_model_params, tmpdir
     ["get_model_fn", "get_model_params"],
     [(xgboost_train, {"objective": "multi:softmax", "num_class": 8}), (xgboost_classifier, {})],
 )
-@need_gpu
 def test_multi_classifier_gpu(get_model_fn, get_model_params, tmpdir):
     X, y = get_classification_data(classes=8)
     model = get_model_fn(X, y, **get_model_params)
@@ -231,7 +225,6 @@ def test_multi_classifier_cpu(get_model_fn, get_model_params, tmpdir):
     ["get_model_fn", "get_model_params"],
     [(xgboost_train, {"objective": "reg:squarederror"}), (xgboost_regressor, {})],
 )
-@need_gpu
 def test_regressor_gpu(get_model_fn, get_model_params, tmpdir):
     X, y = get_regression_data()
     model = get_model_fn(X, y, **get_model_params)
@@ -266,7 +259,6 @@ def test_regressor_cpu(get_model_fn, get_model_params, tmpdir):
         (xgboost_regressor, "xgboost.json"),
     ],
 )
-@need_gpu
 def test_model_file_gpu(get_model_fn, expected_model_filename, tmpdir):
     X, y = get_regression_data()
     model = get_model_fn(X, y)
@@ -292,7 +284,6 @@ def test_model_file_cpu(get_model_fn, expected_model_filename, tmpdir):
     assert model_path.is_file()
 
 
-@need_gpu
 def test_fil_op_exports_own_config(tmpdir):
     X, y = get_regression_data()
     model = xgboost_train(X, y, objective="reg:squarederror")
@@ -309,7 +300,6 @@ def test_fil_op_exports_own_config(tmpdir):
     assert config.output[0].dims == [1]
 
 
-@need_gpu
 def test_fil_op_compute_schema():
     X, y = get_regression_data()
     model = xgboost_train(X, y, objective="reg:squarederror")
@@ -323,7 +313,6 @@ def test_fil_op_compute_schema():
     assert out_schema.column_names == ["output__0"]
 
 
-@need_gpu
 def test_fil_schema_validation():
     X, y = get_regression_data()
     model = xgboost_train(X, y, objective="reg:squarederror")


### PR DESCRIPTION
Removing GPU restriction for FIL operator tests

- #321 added a condition to restrict FIL operator backend tests to only run on GPU. Removing this to see if this restriction still applies.