### PR TITLE
Remove runtime parameter from implicit ensemble tests

### DIFF
--- a/tests/unit/systems/ops/implicit/test_op.py
+++ b/tests/unit/systems/ops/implicit/test_op.py
@@ -25,7 +25,6 @@ from tritonclient import grpc as grpcclient
 from merlin.schema import ColumnSchema, Schema
 from merlin.systems.dag.ensemble import Ensemble
 from merlin.systems.dag.ops.implicit import PredictImplicit
-from merlin.systems.dag.runtimes.triton import TritonExecutorRuntime
 from merlin.systems.triton.utils import run_triton_server
 
 TRITON_SERVER_PATH = shutil.which("tritonserver")


### PR DESCRIPTION
Remove runtime parameter from implicit ensemble tests. 

Goal. Fix the failing test that runs in our GPU environment on the Implicit op.

These tests currently fail the second time they run. (`None`, is equivalent to `TritonExecutorRuntime`, since that's the default). I think this is because there is some memory being managed somewhere (possibly in implicit) that is not being cleaned up completely after the tests complete. Causing a CUDA out-of-memory error.