### PR TITLE
Fix Pytorch integration test postmerge test

### DIFF
--- a/.github/workflows/postmerge-gpu.yml
+++ b/.github/workflows/postmerge-gpu.yml
@@ -6,7 +6,6 @@ on:
     branches: [main]
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
-  pull_request:
 
 jobs:
   gpu-ci-postmerge:

--- a/.github/workflows/postmerge-gpu.yml
+++ b/.github/workflows/postmerge-gpu.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+  pull_request:
 
 jobs:
   gpu-ci-postmerge:

--- a/merlin/systems/triton/conversions.py
+++ b/merlin/systems/triton/conversions.py
@@ -105,9 +105,9 @@ def match_representations(schema: Schema, dict_array: Dict[str, Any]) -> Dict[st
                 aligned[offs_name] = offsets
 
             if dtype != md.unknown:
-                aligned[vals_name] = aligned[vals_name].astype(dtype.to_numpy)
+                aligned[vals_name] = _astype(aligned[vals_name], dtype)
 
-            aligned[offs_name] = aligned[offs_name].astype("int32")
+            aligned[offs_name] = _astype(aligned[offs_name], md.dtype("int32"))
         else:
             try:
                 # Look for values and offsets that already exist,
@@ -120,7 +120,7 @@ def match_representations(schema: Schema, dict_array: Dict[str, Any]) -> Dict[st
                 aligned[col_name] = dict_array[col_name]
 
             if dtype != md.unknown:
-                aligned[col_name] = aligned[col_name].astype(dtype.to_numpy)
+                aligned[col_name] = _astype(aligned[col_name], dtype)
 
     return aligned
 
@@ -137,6 +137,30 @@ def _from_values_offsets(values, offsets, shape):
         )
 
     return values.reshape(new_shape)
+
+
+@singledispatch
+def _astype(value, target_dtype):
+    raise NotImplementedError(f"_to_dtype not implemented for {type(value)}")
+
+
+@_astype.register
+def _(array: np.ndarray, target_dtype: md.DType):
+    return array.astype(target_dtype.to("numpy"))
+
+
+if cp:
+
+    @_astype.register
+    def _(array: cp.ndarray, target_dtype: md.DType):
+        return array.astype(target_dtype.to("cupy"))
+
+
+if torch:
+
+    @_astype.register
+    def _(tensor: torch.Tensor, target_dtype: md.DType):
+        return tensor.to(target_dtype.to("torch"))
 
 
 @singledispatch

--- a/merlin/systems/triton/conversions.py
+++ b/merlin/systems/triton/conversions.py
@@ -146,14 +146,14 @@ def _astype(value, target_dtype):
 
 @_astype.register
 def _(array: np.ndarray, target_dtype: md.DType):
-    return array.astype(target_dtype.to("numpy"))
+    return array.astype(target_dtype.name)
 
 
 if cp:
 
     @_astype.register
     def _(array: cp.ndarray, target_dtype: md.DType):
-        return array.astype(target_dtype.to("cupy"))
+        return array.astype(target_dtype.name)
 
 
 if torch:

--- a/tests/integration/t4r/test_pytorch_backend.py
+++ b/tests/integration/t4r/test_pytorch_backend.py
@@ -29,6 +29,7 @@ data_conversions = pytest.importorskip("merlin.systems.triton.conversions")
 tritonclient = pytest.importorskip("tritonclient")
 grpcclient = pytest.importorskip("tritonclient.grpc")
 
+from merlin.core.compat import HAS_GPU  # noqa
 from merlin.core.dispatch import make_df  # noqa
 from merlin.systems.dag import Ensemble  # noqa
 from merlin.systems.dag.ops.pytorch import PredictPyTorch  # noqa
@@ -39,6 +40,7 @@ TRITON_SERVER_PATH = shutil.which("tritonserver")
 
 
 @pytest.mark.skipif(not TRITON_SERVER_PATH, reason="triton server not found")
+@pytest.mark.skipif(not HAS_GPU, reason="GPU Device required for test")
 def test_serve_t4r_with_torchscript(tmpdir):
     # ===========================================
     # Generate training data

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ sitepackages=true
 ; need to add some back.
 setenv = 
     TF_GPU_ALLOCATOR=cuda_malloc_async
-    LD_LIBRARY_PATH=/opt/tritonserver/backends/pytorch
+    LD_LIBRARY_PATH=/opt/tritonserver/backends/pytorch:{env:LD_LIBRARY_PATH}
 passenv =
     OPAL_PREFIX
 deps =


### PR DESCRIPTION
Fix Pytorch integration test postmerge test

- Extends `LD_LIBRARY_PATH` instead of replacing it completely
  - This was causing an error `CUDA driver version is insufficient for CUDA runtime version`
  - I suspect this might be due to a combination of other CUDA-related enviroment variables that are not passed through to the tox environment.
- Extends `match_representations` type coercion to work with torch tensors