### PR TITLE
Update handling of TensorFlow signature input names to support 2.12

### DIFF
--- a/merlin/systems/dag/ops/tensorflow.py
+++ b/merlin/systems/dag/ops/tensorflow.py
@@ -170,7 +170,8 @@ def _ensure_input_spec_includes_names(model):
 
 def _build_schema_from_signature(signature):
     schema = Schema()
-    for col_name, col in signature.items():
+    for _, col in signature.items():
+        col_name = col.name
         if "__offsets" in col_name or "__values" in col_name:
             col_name = col_name.replace("__offsets", "").replace("__values", "")
             col_values_sig = signature[f"{col_name}__values"]

--- a/requirements/test-cpu.txt
+++ b/requirements/test-cpu.txt
@@ -1,7 +1,6 @@
 -r test.txt
 
 faiss-cpu==1.7.2
-tensorflow<=2.9.0
 treelite==2.4.0
 treelite_runtime==2.4.0
 torch~=1.12


### PR DESCRIPTION
Updates signature handling in the `PredictTensorflow` operator to support TensorFlow 2.12. Where the inputs to the model are not in snake_case format. (are in kebab-case instead)

## Details

In our [unit test of the PredictTensorflow operator](https://github.com/NVIDIA-Merlin/systems/blob/b23ff2108934f67d171bab147fed33f87f6f622a/tests/unit/systems/dag/runtimes/local/ops/tensorflow/test_ensemble.py#L129) we construct a model with the following inputs `['name-cat', 'name-string']`.

In TensorFlow 2.11 and earlier, if you save and the reload the model,
and then inspect the following `model.signatures["serving_default"].structured_input_signature[1]`

you get this in 2.11 and earlier:

```
{'name-cat': TensorSpec(shape=(None,), dtype=tf.int64, name='name_cat'),
 'name-string': TensorSpec(shape=(None,), dtype=tf.int64, name='name_string')}
```

and this in 2.12

```
{'name_string': TensorSpec(shape=(None,), dtype=tf.int64, name='name-string'),
 'name_cat': TensorSpec(shape=(None,), dtype=tf.int64, name='name-cat')}
```

~the values are the same TensorSpec~. the keys are different, and the name in the tensor spect are different, In 2.12 the keys have been converted from kebab-case to snake_case. While in 2.11 and earlier this is the case  for the TensorSpec names. Currently these keys we're using to construct the input_schema of the operator.  Which then results in a mismatach between what the graph expects (keys with kebab-case) and what the op claims to expect 'snake_case' keys, and the following error during graph construction.

```
ValueError: Missing columns ['name-cat', 'name-string'] found in operator PredictTensorflow during compute_selector
```

This PR updates to use the `TensorSpec.name` instead which has the correct input name.

