### PR TITLE
Update format of traceback in executor model to return string instead of list

### DIFF
--- a/merlin/systems/triton/models/executor_model.py
+++ b/merlin/systems/triton/models/executor_model.py
@@ -101,10 +101,7 @@ class TritonPythonModel:
         except Exception as exc:
             import traceback
 
-            raise pb_utils.TritonModelException(
-                f"Error: {type(exc)} - {str(exc)}, "
-                f"Traceback: {traceback.format_tb(exc.__traceback__)}"
-            ) from exc
+            raise pb_utils.TritonModelException(traceback.format_exc()) from exc
 
         return tensor_table_to_triton_response(outputs, self.ensemble.output_schema)
 


### PR DESCRIPTION
## Goal

Improve readability of traceback when an error occurs in the executor model.

## Example

### Before

![image](https://github.com/NVIDIA-Merlin/systems/assets/1216955/f4ed6211-aff4-4efd-b10e-c6c6fffc84fd)


```
InferenceServerException: [StatusCode.INTERNAL] Error: <class 'TypeError'> - int() argument must be a string, a bytes-like object or a number, not 'NoneType', Traceback: ['  File "/tmp/example-integration/examples/poc_ensemble/executor_model/1/model.py", line 100, in execute\n    outputs = self.ensemble.transform(inputs, runtime=TritonExecutorRuntime())\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/systems/dag/ensemble.py", line 78, in transform\n    return runtime.transform(self.graph, transformable)\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/systems/dag/runtimes/base_runtime.py", line 53, in transform\n    return self.executor.transform(transformable, [graph.output_node])\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 87, in transform\n    transformed_data = self._execute_node(node, transformable, capture_dtypes, strict)\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 101, in _execute_node\n    upstream_outputs = self._run_upstream_transforms(\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 114, in _run_upstream_transforms\n    node_output = self._execute_node(\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 101, in _execute_node\n    upstream_outputs = self._run_upstream_transforms(\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 114, in _run_upstream_transforms\n    node_output = self._execute_node(\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 101, in _execute_node\n    upstream_outputs = self._run_upstream_transforms(\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 114, in _run_upstream_transforms\n    node_output = self._execute_node(\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 101, in _execute_node\n    upstream_outputs = self._run_upstream_transforms(\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 114, in _run_upstream_transforms\n    node_output = self._execute_node(\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 101, in _execute_node\n    upstream_outputs = self._run_upstream_transforms(\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 114, in _run_upstream_transforms\n    node_output = self._execute_node(\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 101, in _execute_node\n    upstream_outputs = self._run_upstream_transforms(\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 114, in _run_upstream_transforms\n    node_output = self._execute_node(\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 101, in _execute_node\n    upstream_outputs = self._run_upstream_transforms(\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 114, in _run_upstream_transforms\n    node_output = self._execute_node(\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 107, in _execute_node\n    transform_output = self._run_node_transform(node, transform_input, capture_dtypes, strict)\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 227, in _run_node_transform\n    raise exc\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 214, in _run_node_transform\n    transformed_data = node.op.transform(selection, input_data)\n', '  File "/usr/local/lib/python3.8/dist-packages/merlin/systems/dag/ops/feast.py", line 242, in transform\n    feature_array = array_constructor(feature_value).astype(\n']
```

### After

![image](https://github.com/NVIDIA-Merlin/systems/assets/1216955/74898b03-50ad-468f-a4e4-bd6aaf43f5d0)

```
InferenceServerException: [StatusCode.INTERNAL] Traceback (most recent call last):
  File "/tmp/example-integration/examples/poc_ensemble/executor_model/1/model.py", line 100, in execute
    outputs = self.ensemble.transform(inputs, runtime=TritonExecutorRuntime())
  File "/usr/local/lib/python3.8/dist-packages/merlin/systems/dag/ensemble.py", line 78, in transform
    return runtime.transform(self.graph, transformable)
  File "/usr/local/lib/python3.8/dist-packages/merlin/systems/dag/runtimes/base_runtime.py", line 53, in transform
    return self.executor.transform(transformable, [graph.output_node])
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 87, in transform
    transformed_data = self._execute_node(node, transformable, capture_dtypes, strict)
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 101, in _execute_node
    upstream_outputs = self._run_upstream_transforms(
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 114, in _run_upstream_transforms
    node_output = self._execute_node(
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 101, in _execute_node
    upstream_outputs = self._run_upstream_transforms(
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 114, in _run_upstream_transforms
    node_output = self._execute_node(
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 101, in _execute_node
    upstream_outputs = self._run_upstream_transforms(
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 114, in _run_upstream_transforms
    node_output = self._execute_node(
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 101, in _execute_node
    upstream_outputs = self._run_upstream_transforms(
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 114, in _run_upstream_transforms
    node_output = self._execute_node(
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 101, in _execute_node
    upstream_outputs = self._run_upstream_transforms(
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 114, in _run_upstream_transforms
    node_output = self._execute_node(
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 101, in _execute_node
    upstream_outputs = self._run_upstream_transforms(
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 114, in _run_upstream_transforms
    node_output = self._execute_node(
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 101, in _execute_node
    upstream_outputs = self._run_upstream_transforms(
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 114, in _run_upstream_transforms
    node_output = self._execute_node(
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 107, in _execute_node
    transform_output = self._run_node_transform(node, transform_input, capture_dtypes, strict)
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 227, in _run_node_transform
    raise exc
  File "/usr/local/lib/python3.8/dist-packages/merlin/dag/executors.py", line 214, in _run_node_transform
    transformed_data = node.op.transform(selection, input_data)
  File "/usr/local/lib/python3.8/dist-packages/merlin/systems/dag/ops/feast.py", line 242, in transform
    feature_array = array_constructor(feature_value).astype(
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'

```