### PR TITLE
Remove `use_gpu` argument from Implicit model example notebook

### DIFF
--- a/examples/Serving-An-Implicit-Model-With-Merlin-Systems.ipynb
+++ b/examples/Serving-An-Implicit-Model-With-Merlin-Systems.ipynb
@@ -106,8 +106,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ensemble_export_path = os.environ.get(\"OUTPUT_DATA_DIR\", \"ensemble\")\n",
-    "USE_GPU = bool(int(os.environ.get(\"USE_GPU\", \"1\")))"
+    "ensemble_export_path = os.environ.get(\"OUTPUT_DATA_DIR\", \"ensemble\")"
    ]
   },
   {
@@ -160,7 +159,7 @@
     }
    ],
    "source": [
-    "model = BayesianPersonalizedRanking(use_gpu=USE_GPU)\n",
+    "model = BayesianPersonalizedRanking()\n",
     "model.fit(train_transformed)"
    ]
   },


### PR DESCRIPTION
Removes the `use_gpu` argument from the Implicit model example notebook (`examples/Serving-An-Implicit-Model-With-Merlin-Systems.ipynb`).

This is to support running this notebook as an integration test in a CUDA 12 Environment. [Implicit](https://github.com/benfred/implicit) currnently supports CUDA 11.

The model class we're calling should select the GPU version if it can successfully load the GPU accelerated version (currenlty in a CUDA 11 environment)