### PR TITLE
make the xgboost notebook example runnable

### DIFF
--- a/examples/Serving-An-XGboost-Model-With-Merlin-Systems.ipynb
+++ b/examples/Serving-An-XGboost-Model-With-Merlin-Systems.ipynb
@@ -85,28 +85,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "d0385d38",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-06-21 01:35:01.725525: I tensorflow/core/platform/cpu_feature_guard.cc:194] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX\n",
+      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "/usr/local/lib/python3.8/dist-packages/merlin/dtypes/mappings/torch.py:43: UserWarning: PyTorch dtype mappings did not load successfully due to an error: No module named 'torch'\n",
+      "  warn(f\"PyTorch dtype mappings did not load successfully due to an error: {exc.msg}\")\n",
+      "2023-06-21 01:35:03.041967: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:998] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-06-21 01:35:03.042338: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:998] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-06-21 01:35:03.042470: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:998] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n"
+     ]
+    }
+   ],
    "source": [
+    "import os\n",
     "from merlin.core.utils import Distributed\n",
     "from merlin.models.xgb import XGBoost\n",
     "import nvtabular as nvt\n",
     "import numpy as np\n",
     "from merlin.schema.tags import Tags\n",
     "\n",
-    "from merlin.datasets.entertainment import get_movielens"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f79d5736",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ensemble_export_path = os.environ.get(\"OUTPUT_DATA_DIR\", \"ensemble\")"
+    "from merlin.datasets.entertainment import get_movielens\n",
+    "\n",
+    "ensemble_export_path = os.environ.get(\"OUTPUT_DATA_DIR\", \"/workspace/ensemble\")"
    ]
   },
   {
@@ -119,17 +126,30 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-08-05 22:27:29.446602: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:991] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-08-05 22:27:29.447091: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:991] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-08-05 22:27:29.447227: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:991] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "downloading ml-100k.zip: 4.94MB [00:03, 1.45MB/s]                                                                                                                                                                                                                                                                                                                                         \n",
-      "unzipping files: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 24/24 [00:00<00:00, 262.32files/s]\n",
-      "INFO:merlin.datasets.entertainment.movielens.dataset:starting ETL..\n",
-      "/usr/local/lib/python3.8/dist-packages/cudf/core/frame.py:384: UserWarning: The deep parameter is ignored and is only included for pandas compatibility.\n",
-      "  warnings.warn(\n",
-      "2022-08-05 22:27:39,947 - distributed.diskutils - INFO - Found stale lock file and directory '/workspace/dask-worker-space/worker-oqemvhkv', purging\n",
-      "2022-08-05 22:27:39,947 - distributed.preloading - INFO - Import preload module: dask_cuda.initialize\n",
-      "[22:27:41] task [xgboost.dask]:tcp://127.0.0.1:41809 got new rank 0\n"
+      "INFO:distributed.http.proxy:To route to workers diagnostics web server please install jupyter-server-proxy: python -m pip install jupyter-server-proxy\n",
+      "INFO:distributed.scheduler:State start\n",
+      "INFO:distributed.scheduler:  Scheduler at:     tcp://127.0.0.1:36719\n",
+      "INFO:distributed.scheduler:  dashboard at:            127.0.0.1:8787\n",
+      "INFO:distributed.nanny:        Start Nanny at: 'tcp://127.0.0.1:40691'\n",
+      "2023-06-21 01:35:06,300 - distributed.preloading - INFO - Creating preload: dask_cuda.initialize\n",
+      "2023-06-21 01:35:06,300 - distributed.preloading - INFO - Import preload module: dask_cuda.initialize\n",
+      "INFO:distributed.scheduler:Register worker <WorkerState 'tcp://127.0.0.1:36517', name: 0, status: init, memory: 0, processing: 0>\n",
+      "INFO:distributed.scheduler:Starting worker compute stream, tcp://127.0.0.1:36517\n",
+      "INFO:distributed.core:Starting established connection to tcp://127.0.0.1:36022\n",
+      "INFO:distributed.scheduler:Receive client connection: Client-d9f3799e-0fd3-11ee-9aaa-0242ac110002\n",
+      "INFO:distributed.core:Starting established connection to tcp://127.0.0.1:36024\n",
+      "2023-06-21 01:35:06.949449: I tensorflow/core/platform/cpu_feature_guard.cc:194] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX\n",
+      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "2023-06-21 01:35:08.276325: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:998] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-06-21 01:35:08.276683: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:998] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-06-21 01:35:08.276821: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:998] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "/usr/local/lib/python3.8/dist-packages/xgboost/dask.py:884: RuntimeWarning: coroutine 'Client._wait_for_workers' was never awaited\n",
+      "  client.wait_for_workers(n_workers)\n",
+      "RuntimeWarning: Enable tracemalloc to get the object allocation traceback\n",
+      "INFO:distributed.worker:Run out-of-band function '_start_tracker'\n",
+      "INFO:distributed.scheduler:Receive client connection: Client-worker-dc505c7b-0fd3-11ee-9baa-0242ac110002\n",
+      "INFO:distributed.core:Starting established connection to tcp://127.0.0.1:60628\n",
+      "[01:35:10] task [xgboost.dask-0]:tcp://127.0.0.1:36517 got new rank 0\n"
      ]
     },
     {
@@ -137,22 +157,31 @@
      "output_type": "stream",
      "text": [
       "[0]\ttrain-rmse:2.36952\n",
-      "[20]\ttrain-rmse:0.95316\n",
-      "[40]\ttrain-rmse:0.92447\n",
-      "[60]\ttrain-rmse:0.90741\n",
-      "[80]\ttrain-rmse:0.89437\n",
-      "[84]\ttrain-rmse:0.89138\n"
+      "[20]\ttrain-rmse:0.94937\n",
+      "[40]\ttrain-rmse:0.92392\n",
+      "[60]\ttrain-rmse:0.90948\n",
+      "[80]\ttrain-rmse:0.89700\n",
+      "[84]\ttrain-rmse:0.89577\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:distributed.scheduler:Remove client Client-d9f3799e-0fd3-11ee-9aaa-0242ac110002\n",
+      "INFO:distributed.core:Received 'close-stream' from tcp://127.0.0.1:36024; closing.\n",
+      "INFO:distributed.scheduler:Remove client Client-d9f3799e-0fd3-11ee-9aaa-0242ac110002\n",
+      "INFO:distributed.scheduler:Close client connection: Client-d9f3799e-0fd3-11ee-9aaa-0242ac110002\n"
      ]
     }
    ],
    "source": [
-    "\n",
     "train, _ = get_movielens(variant='ml-100k')\n",
     "\n",
-    "preprocess_categories = ['movieId', 'userId', 'genres'] >> nvt.ops.Categorify(freq_threshold=2, dtype=np.int32)\n",
+    "preprocess_categories = ['movieId', 'userId'] >> nvt.ops.Categorify(freq_threshold=2, dtype=np.int32)\n",
     "preprocess_rating = ['rating'] >> nvt.ops.AddTags(tags=[Tags.TARGET, Tags.REGRESSION])\n",
     "\n",
-    "train_workflow = nvt.Workflow(preprocess_categories + preprocess_rating + train.schema.without(['rating_binary', 'title']).column_names)\n",
+    "train_workflow = nvt.Workflow(preprocess_categories + preprocess_rating + train.schema.without(['rating_binary', 'title', 'genres']).column_names)\n",
     "train_transformed = train_workflow.fit_transform(train)\n",
     "\n",
     "with Distributed():\n",
@@ -442,16 +471,24 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "2fefd5b8",
+   "id": "6e7361ee",
    "metadata": {},
    "outputs": [],
    "source": [
     "from merlin.systems.triton import convert_df_to_triton_input\n",
     "import tritonclient.grpc as grpcclient\n",
     "\n",
-    "ten_examples = train.compute().drop(columns=['rating', 'title', 'rating_binary'])[:10]\n",
-    "inputs = convert_df_to_triton_input(inf_workflow.input_schema, ten_examples, grpcclient.InferInput)\n",
-    "\n",
+    "ten_examples = train.compute().drop(columns=['rating', 'title', 'rating_binary', 'genres'])[:10]\n",
+    "inputs = convert_df_to_triton_input(inf_workflow.input_schema, ten_examples, grpcclient.InferInput)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "2fefd5b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "outputs = [\n",
     "    grpcclient.InferRequestedOutput(col)\n",
     "    for col in inf_ops.output_schema.column_names\n",
@@ -471,7 +508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "6ddd35cc",
    "metadata": {},
    "outputs": [],
@@ -481,7 +518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "6f28fdfe",
    "metadata": {},
    "outputs": [
@@ -489,11 +526,32 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/lib/python3.8/dist-packages/distributed/node.py:180: UserWarning: Port 8787 is already in use.\n",
+      "/usr/local/lib/python3.8/dist-packages/distributed/node.py:182: UserWarning: Port 8787 is already in use.\n",
       "Perhaps you already have a cluster running?\n",
-      "Hosting the HTTP server on port 35647 instead\n",
+      "Hosting the HTTP server on port 40547 instead\n",
       "  warnings.warn(\n",
-      "2022-08-05 22:28:22,197 - distributed.preloading - INFO - Import preload module: dask_cuda.initialize\n"
+      "INFO:distributed.scheduler:State start\n",
+      "INFO:distributed.scheduler:  Scheduler at:     tcp://127.0.0.1:40951\n",
+      "INFO:distributed.scheduler:  dashboard at:           127.0.0.1:40547\n",
+      "INFO:distributed.nanny:        Start Nanny at: 'tcp://127.0.0.1:46561'\n",
+      "2023-06-21 01:35:14,513 - distributed.preloading - INFO - Creating preload: dask_cuda.initialize\n",
+      "2023-06-21 01:35:14,513 - distributed.preloading - INFO - Import preload module: dask_cuda.initialize\n",
+      "INFO:distributed.scheduler:Register worker <WorkerState 'tcp://127.0.0.1:38759', name: 0, status: init, memory: 0, processing: 0>\n",
+      "INFO:distributed.scheduler:Starting worker compute stream, tcp://127.0.0.1:38759\n",
+      "INFO:distributed.core:Starting established connection to tcp://127.0.0.1:35984\n",
+      "INFO:distributed.scheduler:Receive client connection: Client-ded71687-0fd3-11ee-9aaa-0242ac110002\n",
+      "INFO:distributed.core:Starting established connection to tcp://127.0.0.1:35998\n",
+      "/usr/local/lib/python3.8/dist-packages/cudf/core/dataframe.py:1165: FutureWarning: The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.\n",
+      "  mask = pd.Series(mask)\n",
+      "2023-06-21 01:35:14.897923: I tensorflow/core/platform/cpu_feature_guard.cc:194] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX\n",
+      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "2023-06-21 01:35:16.220963: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:998] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-06-21 01:35:16.221319: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:998] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-06-21 01:35:16.221452: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:998] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "INFO:distributed.scheduler:Remove client Client-ded71687-0fd3-11ee-9aaa-0242ac110002\n",
+      "INFO:distributed.core:Received 'close-stream' from tcp://127.0.0.1:35998; closing.\n",
+      "INFO:distributed.scheduler:Remove client Client-ded71687-0fd3-11ee-9aaa-0242ac110002\n",
+      "INFO:distributed.scheduler:Close client connection: Client-ded71687-0fd3-11ee-9aaa-0242ac110002\n"
      ]
     }
    ],
@@ -504,7 +562,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "e946de27",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
This notebook was not running because:

* it was missing `import os` (test was passing because it was import `os` in injected cell)
* for some reason, when run on the movielens synthetic dataset, `convert_df_to_triton_input` was failing where it was not before, I believe

The issue with `convert_df_to_triton_input` was that in the schema of the generated dataset (which aligns with the original) we have the `genres` column marked as rugged, list, whereas the generated column is of type int32 or int64. This mismatch causes `convert_df_to_triton` to fail.