### PR TITLE
Subgraph support changes for multistage example

### DIFF
--- a/merlin/systems/dag/ops/faiss.py
+++ b/merlin/systems/dag/ops/faiss.py
@@ -58,11 +58,14 @@ class QueryFaiss(InferenceOperator):
         self._index = None
 
     def load_artifacts(self, artifact_path: str) -> None:
-        filename = Path(self.index_path).name
-        path_artifact = Path(artifact_path)
-        if path_artifact.is_file():
-            path_artifact = path_artifact.parent
-        full_index_path = str(path_artifact / filename)
+        if artifact_path:
+            filename = Path(self.index_path).name
+            path_artifact = Path(artifact_path)
+            if path_artifact.is_file():
+                path_artifact = path_artifact.parent
+            full_index_path = str(path_artifact / filename)
+        else:
+            full_index_path = self.index_path
         index = faiss.read_index(full_index_path)
 
         if HAS_GPU:

--- a/merlin/systems/dag/ops/feast.py
+++ b/merlin/systems/dag/ops/feast.py
@@ -288,7 +288,4 @@ class QueryFeast(InferenceOperator):
 
     @property
     def supported_formats(self) -> DataFormats:
-        return (
-            DataFormats.NUMPY_TENSOR_TABLE
-            | DataFormats.CUPY_TENSOR_TABLE
-        )
+        return DataFormats.NUMPY_TENSOR_TABLE | DataFormats.CUPY_TENSOR_TABLE

--- a/merlin/systems/dag/ops/feast.py
+++ b/merlin/systems/dag/ops/feast.py
@@ -5,7 +5,7 @@ import numpy as np
 from feast import FeatureStore, ValueType
 
 from merlin.core.protocols import Transformable
-from merlin.dag import ColumnSelector
+from merlin.dag import ColumnSelector, DataFormats
 from merlin.schema import ColumnSchema, Schema
 from merlin.systems.dag.ops.operator import InferenceOperator
 
@@ -285,3 +285,10 @@ class QueryFeast(InferenceOperator):
             return f"{output_prefix}_{col_name}"
         else:
             return col_name
+
+    @property
+    def supported_formats(self) -> DataFormats:
+        return (
+            DataFormats.NUMPY_TENSOR_TABLE
+            | DataFormats.CUPY_TENSOR_TABLE
+        )

--- a/merlin/systems/dag/ops/implicit.py
+++ b/merlin/systems/dag/ops/implicit.py
@@ -57,14 +57,15 @@ class PredictImplicit(InferenceOperator):
         return {k: v for k, v in self.__dict__.items() if k != "model"}
 
     def load_artifacts(self, artifact_path: str):
-        model_file = pathlib.Path(artifact_path) / "model.npz"
+        if artifact_path:
+            model_file = pathlib.Path(artifact_path) / "model.npz"
 
-        model_module_name = self.model_module_name
-        model_class_name = self.model_class_name
-        model_module = importlib.import_module(model_module_name)
-        model_cls = getattr(model_module, model_class_name)
+            model_module_name = self.model_module_name
+            model_class_name = self.model_class_name
+            model_module = importlib.import_module(model_module_name)
+            model_cls = getattr(model_module, model_class_name)
 
-        self.model = model_cls.load(str(model_file))
+            self.model = model_cls.load(str(model_file))
 
     def save_artifacts(self, artifact_path: str):
         model_path = pathlib.Path(artifact_path) / "model.npz"

--- a/merlin/systems/dag/ops/operator.py
+++ b/merlin/systems/dag/ops/operator.py
@@ -54,24 +54,6 @@ class InferenceOperator(BaseOperator):
             "from the base operator."
         )
 
-    def load_artifacts(self, artifact_path: str) -> None:
-        """Load artifacts from disk required for operator function.
-
-        Parameters
-        ----------
-        artifact_path : str
-            The path where artifacts are loaded from
-        """
-
-    def save_artifacts(self, artifact_path: str) -> None:
-        """Save artifacts required to be reload operator state from disk
-
-        Parameters
-        ----------
-        artifact_path : str
-            The path where artifacts are to be saved
-        """
-
     @abstractmethod
     def export(
         self,

--- a/merlin/systems/dag/ops/tensorflow.py
+++ b/merlin/systems/dag/ops/tensorflow.py
@@ -132,10 +132,8 @@ class PredictTensorflow(InferenceOperator):
 
     @property
     def supported_formats(self) -> DataFormats:
-        return (
-            DataFormats.NUMPY_TENSOR_TABLE
-            | DataFormats.CUPY_TENSOR_TABLE
-        )
+        return DataFormats.NUMPY_TENSOR_TABLE | DataFormats.CUPY_TENSOR_TABLE
+
 
 def _construct_schemas_from_model(model, *, signature_name="serving_default", tag_set="serve"):
     # Importing here because tensorflow is an optional dependency of Merlin Systems
@@ -170,5 +168,3 @@ def _build_schema_from_signature(signature_def_inputs_or_outputs):
         col_schema = ColumnSchema(col_name, dtype=col_dtype, dims=col_dims)
         schema.column_schemas[col_name] = col_schema
     return schema
-
-

--- a/merlin/systems/dag/ops/tensorflow.py
+++ b/merlin/systems/dag/ops/tensorflow.py
@@ -21,7 +21,7 @@ os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
 from merlin.core.compat.tensorflow import tensorflow as tf  # noqa
 from merlin.core.protocols import Transformable  # noqa
-from merlin.dag import ColumnSelector  # noqa
+from merlin.dag import ColumnSelector, DataFormats  # noqa
 from merlin.schema import ColumnSchema, Schema  # noqa
 from merlin.systems.dag.ops.operator import InferenceOperator  # noqa
 from merlin.table import TensorflowColumn, TensorTable  # noqa
@@ -130,6 +130,12 @@ class PredictTensorflow(InferenceOperator):
         """
         return self.output_schema
 
+    @property
+    def supported_formats(self) -> DataFormats:
+        return (
+            DataFormats.NUMPY_TENSOR_TABLE
+            | DataFormats.CUPY_TENSOR_TABLE
+        )
 
 def _construct_schemas_from_model(model, *, signature_name="serving_default", tag_set="serve"):
     # Importing here because tensorflow is an optional dependency of Merlin Systems
@@ -164,3 +170,5 @@ def _build_schema_from_signature(signature_def_inputs_or_outputs):
         col_schema = ColumnSchema(col_name, dtype=col_dtype, dims=col_dims)
         schema.column_schemas[col_name] = col_schema
     return schema
+
+

--- a/merlin/systems/dag/ops/unroll_features.py
+++ b/merlin/systems/dag/ops/unroll_features.py
@@ -17,7 +17,7 @@
 import numpy as np
 
 from merlin.core.protocols import Transformable
-from merlin.dag import Node, DataFormats
+from merlin.dag import DataFormats, Node
 from merlin.dag.selector import ColumnSelector
 from merlin.schema import Schema
 from merlin.systems.dag.ops.operator import InferenceOperator
@@ -75,7 +75,4 @@ class UnrollFeatures(InferenceOperator):
 
     @property
     def supported_formats(self) -> DataFormats:
-        return (
-            DataFormats.NUMPY_TENSOR_TABLE
-            | DataFormats.CUPY_TENSOR_TABLE
-        )
+        return DataFormats.NUMPY_TENSOR_TABLE | DataFormats.CUPY_TENSOR_TABLE

--- a/merlin/systems/dag/ops/unroll_features.py
+++ b/merlin/systems/dag/ops/unroll_features.py
@@ -17,7 +17,7 @@
 import numpy as np
 
 from merlin.core.protocols import Transformable
-from merlin.dag import Node
+from merlin.dag import Node, DataFormats
 from merlin.dag.selector import ColumnSelector
 from merlin.schema import Schema
 from merlin.systems.dag.ops.operator import InferenceOperator
@@ -72,3 +72,10 @@ class UnrollFeatures(InferenceOperator):
             return self.unroll_cols.selector.names
         else:
             return self.unroll_cols.output_columns.names
+
+    @property
+    def supported_formats(self) -> DataFormats:
+        return (
+            DataFormats.NUMPY_TENSOR_TABLE
+            | DataFormats.CUPY_TENSOR_TABLE
+        )

--- a/merlin/systems/dag/ops/workflow.py
+++ b/merlin/systems/dag/ops/workflow.py
@@ -112,10 +112,6 @@ class TransformWorkflow(InferenceOperator):
 
         return output
 
-
     @property
     def supported_formats(self) -> DataFormats:
-        return (
-            DataFormats.PANDAS_DATAFRAME
-            | DataFormats.CUDF_DATAFRAME
-        )
+        return DataFormats.PANDAS_DATAFRAME | DataFormats.CUDF_DATAFRAME

--- a/merlin/systems/dag/ops/workflow.py
+++ b/merlin/systems/dag/ops/workflow.py
@@ -16,7 +16,7 @@
 from typing import List
 
 from merlin.core.protocols import Transformable
-from merlin.dag import ColumnSelector
+from merlin.dag import ColumnSelector, DataFormats
 from merlin.schema import Schema
 from merlin.systems.dag.ops.operator import InferenceOperator
 from merlin.table import TensorTable
@@ -111,3 +111,11 @@ class TransformWorkflow(InferenceOperator):
             output = TensorTable.from_df(output)
 
         return output
+
+
+    @property
+    def supported_formats(self) -> DataFormats:
+        return (
+            DataFormats.PANDAS_DATAFRAME
+            | DataFormats.CUDF_DATAFRAME
+        )

--- a/merlin/systems/dag/runtimes/triton/runtime.py
+++ b/merlin/systems/dag/runtimes/triton/runtime.py
@@ -134,8 +134,7 @@ class TritonExecutorRuntime(Runtime):
                 if node_config is not None:
                     node_configs.append(node_config)
 
-            if hasattr(node.op, "save_artifacts"):
-                node.op.save_artifacts(str(artifact_path))
+            node.op.save_artifacts(str(artifact_path))
 
         executor_config = self._executor_model_export(path, triton_model_name, ensemble)
 

--- a/merlin/systems/triton/models/executor_model.py
+++ b/merlin/systems/triton/models/executor_model.py
@@ -69,7 +69,9 @@ class TritonPythonModel:
 
         self.ensemble = Ensemble.load(str(ensemble_path))
 
-        for node in list(postorder_iter_nodes(self.ensemble.graph.output_node, flatten_subgraphs=True)):
+        for node in list(
+            postorder_iter_nodes(self.ensemble.graph.output_node, flatten_subgraphs=True)
+        ):
             node.op.load_artifacts(str(ensemble_path))
 
     @triton_multi_request

--- a/merlin/systems/triton/models/executor_model.py
+++ b/merlin/systems/triton/models/executor_model.py
@@ -69,9 +69,8 @@ class TritonPythonModel:
 
         self.ensemble = Ensemble.load(str(ensemble_path))
 
-        for node in list(postorder_iter_nodes(self.ensemble.graph.output_node)):
-            if hasattr(node.op, "load_artifacts"):
-                node.op.load_artifacts(str(ensemble_path))
+        for node in list(postorder_iter_nodes(self.ensemble.graph.output_node, flatten_subgraphs=True)):
+            node.op.load_artifacts(str(ensemble_path))
 
     @triton_multi_request
     @triton_error_handling

--- a/tests/unit/systems/dag/runtimes/local/ops/tensorflow/test_ensemble.py
+++ b/tests/unit/systems/dag/runtimes/local/ops/tensorflow/test_ensemble.py
@@ -119,8 +119,8 @@ def test_workflow_tf_e2e_multi_op_run(tmpdir, dataset, engine, runtime):
 
     response = triton_ens.transform(df, runtime=runtime)
 
-    assert response["predictions"].shape[0].min == df.shape[0]
-    assert response["predictions"].shape[0].max == df.shape[0]
+    assert response["predictions"].shape[0] == df.shape[0]
+    assert response["predictions"].shape[0] == df.shape[0]
 
 
 @pytest.mark.parametrize("engine", ["parquet"])


### PR DESCRIPTION
Added supported format flags for specific operators that may require specific data types internally. Added the capability to load artifacts in a local runtime, was only used previously for triton runtimes after export. Migrated artifact load and save to core https://github.com/NVIDIA-Merlin/core/pull/349. Removed hasattr checks in triton python model class because all operators now have artifact hooks. 